### PR TITLE
Backwards support for Media\Update\Images

### DIFF
--- a/src/EndpointSupport/Images.php
+++ b/src/EndpointSupport/Images.php
@@ -80,12 +80,18 @@ class Images
             return false;
         }
 
-        $decoded = base64_decode($value, true);
+        if (!str_contains($value, 'data:') || !str_contains($value, 'base64,')) {
+            return false;
+        }
+
+        $base64 = substr($value, strpos($value, 'base64,') + strlen('base64,'));
+
+        $decoded = base64_decode($base64, true);
 
         if ($decoded === false) {
             return false;
         }
 
-        return base64_encode($decoded) === $value;
+        return base64_encode($decoded) === $base64;
     }
 }

--- a/src/Endpoints/Media/Update/Images.php
+++ b/src/Endpoints/Media/Update/Images.php
@@ -4,94 +4,9 @@ declare(strict_types=1);
 
 namespace Newman\LaravelTmsApiClient\Endpoints\Media\Update;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelTmsApiClient\EndpointSupport\Images as BaseImages;
 
-class Images
+class Images extends BaseImages
 {
-    use CompilesProperties;
-
-    /**
-     * @var string|null
-     */
-    protected $thumbnail = null;
-
-    /**
-     * @var string|null
-     */
-    protected $placeholder = null;
-
-    /**
-     * @var string|null
-     */
-    protected $playbutton = null;
-
-    /**
-     * @var string|null
-     */
-    protected $logo = null;
-
-    public function thumbnail(?string $imageBase64): static
-    {
-        if (!$this->verifyBase64Encoded($imageBase64)) {
-            throw new \InvalidArgumentException('thumbnail must be a base64 encoded string');
-        }
-
-        $this->thumbnail = $imageBase64;
-
-        return $this;
-    }
-
-    public function placeholder(?string $imageBase64): static
-    {
-        if (!$this->verifyBase64Encoded($imageBase64)) {
-            throw new \InvalidArgumentException('placeholder must be a base64 encoded string');
-        }
-
-        $this->placeholder = $imageBase64;
-
-        return $this;
-    }
-
-    public function playbutton(?string $imageBase64): static
-    {
-        if (!$this->verifyBase64Encoded($imageBase64)) {
-            throw new \InvalidArgumentException('playbutton must be a base64 encoded string');
-        }
-
-        $this->playbutton = $imageBase64;
-
-        return $this;
-    }
-
-    public function logo(?string $imageBase64): static
-    {
-        if (!$this->verifyBase64Encoded($imageBase64)) {
-            throw new \InvalidArgumentException('logo must be a base64 encoded string');
-        }
-
-        $this->logo = $imageBase64;
-
-        return $this;
-    }
-
-    private function verifyBase64Encoded(?string $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (!str_contains($value, 'data:') || !str_contains($value, 'base64,')) {
-            return false;
-        }
-
-        $base64 = substr($value, strpos($value, 'base64,') + strlen('base64,'));
-
-        $decoded = base64_decode($base64, true);
-
-        if ($decoded === false) {
-            return false;
-        }
-
-        return base64_encode($decoded) === $base64;
-    }
+    //
 }

--- a/tests/EndpointSupport/ImagesTest.php
+++ b/tests/EndpointSupport/ImagesTest.php
@@ -13,20 +13,51 @@ class ImagesTest extends TestCase
     {
         $images = new Images();
 
-        $images->thumbnail('aW1hZ2ViYXNlNjRfMQ==')
-            ->placeholder('aW1hZ2ViYXNlNjRfMg==')
-            ->playbutton('aW1hZ2ViYXNlNjRfMw==')
-            ->logo('aW1hZ2ViYXNlNjRfNA==');
+        $encodedImage = 'data:image/png;base64,' . base64_encode('imagebase64_1');
+
+        $images->thumbnail($encodedImage)
+            ->placeholder($encodedImage)
+            ->playbutton($encodedImage)
+            ->logo($encodedImage);
 
         $this->assertEquals([
-            'thumbnail' => 'aW1hZ2ViYXNlNjRfMQ==',
-            'placeholder' => 'aW1hZ2ViYXNlNjRfMg==',
-            'playbutton' => 'aW1hZ2ViYXNlNjRfMw==',
-            'logo' => 'aW1hZ2ViYXNlNjRfNA==',
+            'thumbnail' => $encodedImage,
+            'placeholder' => $encodedImage,
+            'playbutton' => $encodedImage,
+            'logo' => $encodedImage,
         ], $images->compileAsArray());
     }
 
     public function test_with_non_base64(): void
+    {
+        $images = new Images();
+
+        try {
+            $images->thumbnail('data:image/png;base64,imagebase64_1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('thumbnail must be a base64 encoded string', $e->getMessage());
+        }
+
+        try {
+            $images->placeholder('data:image/png;base64,imagebase64_1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('placeholder must be a base64 encoded string', $e->getMessage());
+        }
+
+        try {
+            $images->playbutton('data:image/png;base64,imagebase64_1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('playbutton must be a base64 encoded string', $e->getMessage());
+        }
+
+        try {
+            $images->logo('data:image/png;base64,imagebase64_1');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('logo must be a base64 encoded string', $e->getMessage());
+        }
+    }
+
+    public function test_without_metadata(): void
     {
         $images = new Images();
 

--- a/tests/Endpoints/Live/CreateTest.php
+++ b/tests/Endpoints/Live/CreateTest.php
@@ -276,20 +276,20 @@ class CreateTest extends TestCase
         $endpoint = new Create('name');
 
         $images = new Images();
-        $images->thumbnail(base64_encode('thumbnail'));
-        $images->placeholder(base64_encode('placeholder'));
-        $images->playbutton(base64_encode('playbutton'));
-        $images->logo(base64_encode('logo'));
+        $images->thumbnail('data:image/png;base64,' . base64_encode('thumbnail'));
+        $images->placeholder('data:image/png;base64,' . base64_encode('placeholder'));
+        $images->playbutton('data:image/png;base64,' . base64_encode('playbutton'));
+        $images->logo('data:image/png;base64,' . base64_encode('logo'));
 
         $endpoint->images($images);
 
         $this->makeBasicAuthEndpointTest($endpoint, [],  [
             'name' => 'name',
             'images' => [
-                'thumbnail' => base64_encode('thumbnail'),
-                'placeholder' => base64_encode('placeholder'),
-                'playbutton' => base64_encode('playbutton'),
-                'logo' => base64_encode('logo'),
+                'thumbnail' => 'data:image/png;base64,' . base64_encode('thumbnail'),
+                'placeholder' => 'data:image/png;base64,' . base64_encode('placeholder'),
+                'playbutton' => 'data:image/png;base64,' . base64_encode('playbutton'),
+                'logo' => 'data:image/png;base64,' . base64_encode('logo'),
             ],
         ]);
     }

--- a/tests/Endpoints/Live/UpdateTest.php
+++ b/tests/Endpoints/Live/UpdateTest.php
@@ -287,20 +287,20 @@ class UpdateTest extends TestCase
         $endpoint = new Update(1);
 
         $images = new Images();
-        $images->thumbnail(base64_encode('thumbnail'));
-        $images->placeholder(base64_encode('placeholder'));
-        $images->playbutton(base64_encode('playbutton'));
-        $images->logo(base64_encode('logo'));
+        $images->thumbnail('data:image/png;base64,' . base64_encode('thumbnail'));
+        $images->placeholder('data:image/png;base64,' . base64_encode('placeholder'));
+        $images->playbutton('data:image/png;base64,' . base64_encode('playbutton'));
+        $images->logo('data:image/png;base64,' . base64_encode('logo'));
 
         $endpoint->images($images);
 
         $this->makeBasicAuthEndpointTest($endpoint, [], [
             'id' => 1,
             'images' => [
-                'thumbnail' => base64_encode('thumbnail'),
-                'placeholder' => base64_encode('placeholder'),
-                'playbutton' => base64_encode('playbutton'),
-                'logo' => base64_encode('logo'),
+                'thumbnail' => 'data:image/png;base64,' . base64_encode('thumbnail'),
+                'placeholder' => 'data:image/png;base64,' . base64_encode('placeholder'),
+                'playbutton' => 'data:image/png;base64,' . base64_encode('playbutton'),
+                'logo' => 'data:image/png;base64,' . base64_encode('logo'),
             ]
         ]);
     }

--- a/tests/Endpoints/Media/UpdateTest.php
+++ b/tests/Endpoints/Media/UpdateTest.php
@@ -11,6 +11,7 @@ use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
 use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
 use Newman\LaravelTmsApiClient\EndpointSupport\Images;
 use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelTmsApiClient\Endpoints\Media\Update\Images as UpdateImages;
 
 class UpdateTest extends TestCase
 {
@@ -54,14 +55,14 @@ class UpdateTest extends TestCase
         $endpoint = new Update(new ByMediaId(1234));
 
         $images = new Images();
-        $images->thumbnail('aW1hZ2ViYXNlNjRfMQ==');
+        $images->thumbnail('data:image/png;base64,aW1hZ2ViYXNlNjRfMQ==');
 
         $endpoint->images($images);
 
         $this->makeBasicAuthEndpointTest($endpoint, [], [
             'id' => 1234,
             'images' => [
-                'thumbnail' => 'aW1hZ2ViYXNlNjRfMQ==',
+                'thumbnail' => 'data:image/png;base64,aW1hZ2ViYXNlNjRfMQ==',
             ],
         ]);
 


### PR DESCRIPTION
Changed Media\Update\Images to extend EndpointsSupport\Images, instead of duplicating code.

Updated tests