### PR TITLE
change withData to withQuery on media delete

### DIFF
--- a/src/Endpoints/Media/Delete.php
+++ b/src/Endpoints/Media/Delete.php
@@ -66,6 +66,6 @@ class Delete extends AbstractEndpoint implements EndpointContract
      */
     public function prepareHttpRequest(PendingRequest $http): void
     {
-        $http->withData(['id' => $this->mediaIds]);
+        $http->withQuery(['id' => $this->mediaIds]);
     }
 }

--- a/tests/Endpoints/Media/DeleteTest.php
+++ b/tests/Endpoints/Media/DeleteTest.php
@@ -11,11 +11,11 @@ class DeleteTest extends TestCase
 {
     public function test_with_single_id(): void
     {
-        $this->makeBasicAuthEndpointTest(new Delete(123), [], ['id' => [123]]);
+        $this->makeBasicAuthEndpointTest(new Delete(123), ['id' => [123]]);
     }
 
     public function test_it_accepts_multiple_ids(): void
     {
-        $this->makeBasicAuthEndpointTest(new Delete([123, 456]), [], ['id' => [123, 456]]);
+        $this->makeBasicAuthEndpointTest(new Delete([123, 456]), ['id' => [123, 456]]);
     }
 }


### PR DESCRIPTION
According to the [docs](https://api.cloudycdn.services/api/v5/docs#/operations/Media/Delete), ID must be query string.