### PR TITLE
Separate client request config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,28 +77,37 @@ TmsApi::createClient('default', new BearerAuthMethod($bearerToken));
 // TmsApi::client('default')->run(...);
 ```
 
-### Configure Client
+### Configure request
 
-**Note:** This will override settings for upcoming requests on `default` client.
+**Note:** These parameters will be present only for a single (upcoming) request and then will reset to defaults.
 
 #### `timeout` and `connectTimeout`
 
 ```php
 use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
 
-TmsApi::client('default')->timeout(30)->connectTimeout(45);
+TmsApi::client('default')->timeout(30)->connectTimeout(45)->run(...);
 ```
 
 #### `withMiddleware`
 
 Append HTTP middleware to this client upcoming requests.
 
-https://laravel.com/docs/9.x/http-client#guzzle-middleware
+https://laravel.com/docs/12.x/http-client#guzzle-middleware
 
 ```php
+use GuzzleHttp\Middleware;
 use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
 
-TmsApi::client('default')->withMiddleware(...);
+TmsApi::client('default')
+    ->withMiddleware(
+        Middleware::mapRequest(function (RequestInterface $request) {
+            $request = $request->withHeader('X-Example', 'Value');
+
+            return $request;
+        })
+    )
+    ->run(....);
 ```
 
 ## Response

--- a/tests/Unit/TmsApiTest.php
+++ b/tests/Unit/TmsApiTest.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Newman\LaravelTmsApiClient\Tests\Unit;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Newman\LaravelTmsApiClient\Auth\ApiKeyAuthMethod;
 use Newman\LaravelTmsApiClient\Client;
+use Newman\LaravelTmsApiClient\Contracts\ClientContract;
 use Newman\LaravelTmsApiClient\Exceptions\InvalidTmsApiClientException;
 use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelTmsApiClient\Tests\Support\GetTestEndpoint;
 use Newman\LaravelTmsApiClient\Tests\TestCase;
 
 class TmsApiTest extends TestCase
@@ -110,5 +114,56 @@ class TmsApiTest extends TestCase
         $this->expectExceptionMessage('TMS Api client auth credentials are not provided.');
 
         TmsApi::client('ipsum');
+    }
+
+    public function test_it_respects_individual_timeouts_on_client(): void
+    {
+        TmsApi::fake();
+
+        /** @var ConfigRepository $config */
+        $config = $this->app->make(ConfigRepository::class);
+
+        $config->set('tms-api.clients', [
+            'ipsum' => [
+                'auth' => [
+                    'username' => 'lorem',
+                    'password' => 'ipsum',
+                ],
+
+                'http' => [
+                    'timeout' => 1,
+                    'connect_timeout' => 1,
+                ],
+            ],
+        ]);
+
+        $runClientTest = function (ClientContract $client, int $timeout, int $connection_timeout) {
+            $actualClientTimeout = null;
+            $actualClientConnectionTimeout = null;
+
+            $clientHttpFactory = $client->buildHttpFactory();
+            $clientHttpFactory->preventStrayRequests();
+            $clientHttpFactory->fake(function (Request $request, array $options) use (&$actualClientTimeout, &$actualClientConnectionTimeout) {
+                $actualClientTimeout = $options['timeout'];
+                $actualClientConnectionTimeout = $options['connect_timeout'];
+
+                if ($request->url() == 'https://api.cloudycdn.services/api/v5/Test?status=ingested') {
+                    return Http::response(['msg' => '', 'code' => 0]);
+                }
+
+                return Http::response('----', 404);
+            });
+
+            $client
+                ->timeout($timeout)
+                ->connectTimeout($connection_timeout)
+                ->run(new GetTestEndpoint);
+
+            $this->assertEquals($timeout, $actualClientTimeout);
+            $this->assertEquals($connection_timeout, $actualClientConnectionTimeout);
+        };
+
+        $runClientTest(TmsApi::client('ipsum'), 15, 15);
+        $runClientTest(TmsApi::client('ipsum'), 20, 20);
     }
 }


### PR DESCRIPTION
- [x] Breaking change


Changed:

```php
TmsApi::client('default')->timeout(30)->connectTimeout(45)->run(...);
```

so that timeouts and middleware is set per request basis, instead of overriding for all upcoming requests within client.

To override defaults after this PR, developers may override the config using code below to override `default` client timeouts in runtime.

```php
Config::set('tms-api.clients.default.http.timeout', 60);
```