### PR TITLE
Naming changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This package helps you to make API calls to Backscreen (a.k.a: Videosher, TET Me
 
 https://api.cloudycdn.services/api/v5/docs
 
+## Upgrade
+
+If you were using 1.x before, follow UPGRADE.md to update your code properly since it contains many breaking changes.
+
 ## Requirements
 - Laravel 11.0+, 12.0+
 - PHP 8.2+
@@ -14,22 +18,22 @@ For laravel versions 9.0, 10.0, see 1.x branch.
 Require the package via Composer:
 
 ```bash
-composer require newman/laravel-tms-api-client
+composer require newman/laravel-backscreen-api-client
 ```
 
 Copy config file to your `config` directory.
 ```bash
-php artisan vendor:publish --tag=tms-api-config
+php artisan vendor:publish --tag=backscreen-api-config
 ```
 
 Add environment variables to your `.env` file.
 
 ```dotenv
-TMS_DEFAULT_USERNAME="API Key"
-TMS_DEFAULT_PASSWORD="API Secret"
+BACKSCREEN_DEFAULT_USERNAME="API Key"
+BACKSCREEN_DEFAULT_PASSWORD="API Secret"
 ```
 
-At last, you can add extra client to your `tms-api.php` config file with other credentials or different default settings.
+At last, you can add extra client to your `backscreen-api.php` config file with other credentials or different default settings.
 
 # :book: Documentation & Usage
 
@@ -38,7 +42,7 @@ At last, you can add extra client to your `tms-api.php` config file with other c
 ### Access client from config
 
 ```php
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 TmsApi::client('default')->run(...);
 ```
@@ -48,8 +52,8 @@ TmsApi::client('default')->run(...);
 We recommend to do this on your `AppServiceProvider`, inside `boot` function.
 
 ```php
-use Newman\LaravelTmsApiClient\Auth\BasicAuthMethod;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Auth\BasicAuthMethod;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $client = TmsApi::createClient('live', new BasicAuthMethod('api key', 'api secret'));
 
@@ -62,8 +66,8 @@ $client = TmsApi::createClient('live', new BasicAuthMethod('api key', 'api secre
 There are some endpoints (e.g. `/User/Login`) which doesn't require any authentication at all.
 
 ```php
-use Newman\LaravelTmsApiClient\Auth\BearerAuthMethod;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Auth\BearerAuthMethod;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 // 1) Retrieve Bearer token without any authentication.
 $response = TmsApi::nullClient()->run(new Login('my@email.com', 'mypassword'));
@@ -86,7 +90,7 @@ TmsApi::createClient('default', new BearerAuthMethod($bearerToken));
 #### `timeout` and `connectTimeout`
 
 ```php
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 TmsApi::client('default')->timeout(30)->connectTimeout(45)->run(...);
 ```
@@ -99,7 +103,7 @@ https://laravel.com/docs/12.x/http-client#guzzle-middleware
 
 ```php
 use GuzzleHttp\Middleware;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 TmsApi::client('default')
     ->withMiddleware(
@@ -135,8 +139,8 @@ Generates a new token.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Token\Generate as TokenGenerate;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate as TokenGenerate;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new TokenGenerate(123456, TokenGenerate\ItemTypeEnum::MEDIA);
 
@@ -165,9 +169,9 @@ Retrieve a list of media.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new MediaList();
 
@@ -221,12 +225,12 @@ Create media.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create as MediaCreate;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Files;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Tags;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create as MediaCreate;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
 
 $endpoint = new MediaCreate('123');
 
@@ -270,12 +274,12 @@ Update media.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update as MediaUpdate;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\ByMediaId;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\ByAssetId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update as MediaUpdate;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByMediaId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByAssetId;
 
 // Select by which identificator to update
 // by media ID
@@ -308,8 +312,8 @@ Delete media by ID/s.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Delete as MediaDelete;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Delete as MediaDelete;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 // Multiple IDs.
 $endpoint = new MediaDelete([1234, 5678]);
@@ -331,8 +335,8 @@ Clone media by ID.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\CloneMedia;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\CloneMedia;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new CloneMedia(1234, 'asset_id_for_the_new_asset');
 
@@ -349,8 +353,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Trim
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Trim;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Trim;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new Trim(1234, '00:00:10', '00:59:59', Trim\TypeEnum::NEW);
 
@@ -367,8 +371,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Generateimage
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\GenerateImage;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\GenerateImage;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new GenerateImage(1234);
 
@@ -387,8 +391,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Reset
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Reset;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Reset;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new Reset(1234));
 ```
@@ -400,8 +404,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Transcode
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Transcode;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Transcode;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new Transcode(1234));
 ```
@@ -413,8 +417,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Canceltranscode
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\CancelTranscode;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\CancelTranscode;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new CancelTranscode(1234));
 ```
@@ -426,8 +430,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Updatesubtitlesfrom
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\UpdateSubtitlesFromSource;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UpdateSubtitlesFromSource;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new UpdateSubtitlesFromSource(1234));
 ```
@@ -439,8 +443,8 @@ https://api.cloudycdn.services/api/v5/docs#/operations/Media/Regeneratepackages
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\RegeneratePackages;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\RegeneratePackages;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new RegeneratePackages(1234);
 
@@ -461,10 +465,10 @@ Retrieve list of manifests.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\ManifestList;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\ManifestList;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new ManifestList();
 
@@ -488,8 +492,8 @@ Create a new media manifest.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Create as MediaManifestCreate;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Create as MediaManifestCreate;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new MediaManifestCreate(1234); // media ID
 
@@ -513,8 +517,8 @@ Update media manifest by manifest ID.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Update as MediaManifestUpdate;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Update as MediaManifestUpdate;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new MediaManifestUpdate(85291); // manifest ID
 
@@ -532,8 +536,8 @@ Delete media manifest by manifest ID.
 **Accepted Auth Methods:** `Basic`, `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Delete as MediaManifestDelete;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Delete as MediaManifestDelete;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new MediaManifestDelete(85291)); // manifest ID
 ```
@@ -549,8 +553,8 @@ Return current user info. Returns the same values as login action, but without a
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\User\Get as UserGet;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Get as UserGet;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new UserGet();
 
@@ -569,8 +573,8 @@ Login user by email & password to retrieve Bearer token.
 **Accepted Auth Methods:** `Null`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\User\Login as UserLogin;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Login as UserLogin;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new UserLogin('my@email.com', 'password');
 
@@ -590,8 +594,8 @@ Logout currently authenticated user.
 **Accepted Auth Methods:** `Bearer token`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\User\Logout as UserLogout;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Logout as UserLogout;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $response = TmsApi::client('default')->run(new UserLogout());
 ```
@@ -607,9 +611,9 @@ Retrieve a list of livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new LiveList();
 
@@ -662,9 +666,9 @@ Create a livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new Create('New Livestream');
 
@@ -764,10 +768,10 @@ Update an existing livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\Update;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Update;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new Update(123);
 
@@ -868,8 +872,8 @@ Turn on an existing livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\On;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\On;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new On(123);
 
@@ -887,8 +891,8 @@ Turn Off an existing livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\Off;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Off;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new Off(123);
 
@@ -906,8 +910,8 @@ Start recording an existing livestream.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelTmsApiClient\Endpoints\Live\Record;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Record;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new Record(123);
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,4 @@
+# Upgrade from `1.x` to `2.x`
+* Rename your laravel config file in `config/tms-api.php` to `config/backscreen-api.php`
+* Namespace changed from `Newman\LaravelTmsApiClient` to `Newman\LaravelBackscreenApiClient`. You should update your laravel code to match the new namespace.
+* Look-out for usages of `->timeout()`, `->connectTimeout()` and `->withMiddleware()`. They are now only per-request basis and doesn't update globally anymore.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "newman/laravel-tms-api-client",
-	"description": "Laravel TMS Api client.",
+	"description": "Laravel Backscreen Api client.",
 	"keywords": [
 		"laravel",
 		"tms",
@@ -35,12 +35,12 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Newman\\LaravelTmsApiClient\\": "src/"
+			"Newman\\LaravelBackscreenApiClient\\": "src/"
 		}
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"Newman\\LaravelTmsApiClient\\Tests\\": "tests/"
+			"Newman\\LaravelBackscreenApiClient\\Tests\\": "tests/"
 		}
 	},
 	"scripts": {
@@ -54,10 +54,10 @@
 	"extra": {
 		"laravel": {
 			"providers": [
-				"Newman\\LaravelTmsApiClient\\ServiceProvider"
+				"Newman\\LaravelBackscreenApiClient\\ServiceProvider"
 			],
 			"aliases": {
-				"TmsApi": "Newman\\LaravelTmsApiClient\\Support\\Facades\\TmsApi"
+				"TmsApi": "Newman\\LaravelBackscreenApiClient\\Support\\Facades\\TmsApi"
 			}
 		}
 	},

--- a/config/backscreen-api.php
+++ b/config/backscreen-api.php
@@ -16,8 +16,8 @@ return [
         'default' => [
             // Basic Auth credentials (Required)
             'auth' => [
-                'username' => env('TMS_DEFAULT_USERNAME'),
-                'password' => env('TMS_DEFAULT_PASSWORD'),
+                'username' => env('BACKSCREEN_DEFAULT_USERNAME'),
+                'password' => env('BACKSCREEN_DEFAULT_PASSWORD'),
             ],
 
             // Default HTTP settings (Optional)

--- a/src/AbstractEndpoint.php
+++ b/src/AbstractEndpoint.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient;
+namespace Newman\LaravelBackscreenApiClient;
 
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 abstract class AbstractEndpoint
 {

--- a/src/Auth/ApiKeyAuthMethod.php
+++ b/src/Auth/ApiKeyAuthMethod.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Auth;
+namespace Newman\LaravelBackscreenApiClient\Auth;
 
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class ApiKeyAuthMethod implements AuthMethodContract
 {

--- a/src/Auth/BasicAuthMethod.php
+++ b/src/Auth/BasicAuthMethod.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Auth;
+namespace Newman\LaravelBackscreenApiClient\Auth;
 
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class BasicAuthMethod implements AuthMethodContract
 {

--- a/src/Auth/BearerAuthMethod.php
+++ b/src/Auth/BearerAuthMethod.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Auth;
+namespace Newman\LaravelBackscreenApiClient\Auth;
 
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class BearerAuthMethod implements AuthMethodContract
 {

--- a/src/Auth/NullAuthMethod.php
+++ b/src/Auth/NullAuthMethod.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Auth;
+namespace Newman\LaravelBackscreenApiClient\Auth;
 
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @codeCoverageIgnore

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient;
+namespace Newman\LaravelBackscreenApiClient;
 
 use Exception;
 use Illuminate\Http\Client\Response;
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\Exceptions\TmsAuthMethodNotAllowed;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Exceptions\TmsAuthMethodNotAllowed;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class Client implements ClientContract
 {

--- a/src/Concerns/CompilesProperties.php
+++ b/src/Concerns/CompilesProperties.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Concerns;
+namespace Newman\LaravelBackscreenApiClient\Concerns;
 
 use Carbon\CarbonInterface;
 use ReflectionClass;

--- a/src/Contracts/AuthMethodContract.php
+++ b/src/Contracts/AuthMethodContract.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Contracts;
+namespace Newman\LaravelBackscreenApiClient\Contracts;
 
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 interface AuthMethodContract
 {

--- a/src/Contracts/ClientContract.php
+++ b/src/Contracts/ClientContract.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Contracts;
+namespace Newman\LaravelBackscreenApiClient\Contracts;
 
 use Illuminate\Http\Client\Response;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
 
 interface ClientContract
 {

--- a/src/Contracts/EndpointContract.php
+++ b/src/Contracts/EndpointContract.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Contracts;
+namespace Newman\LaravelBackscreenApiClient\Contracts;
 
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 interface EndpointContract
 {

--- a/src/Contracts/TmsApiContract.php
+++ b/src/Contracts/TmsApiContract.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Contracts;
+namespace Newman\LaravelBackscreenApiClient\Contracts;
 
 interface TmsApiContract
 {

--- a/src/EndpointSupport/Callback.php
+++ b/src/EndpointSupport/Callback.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\EndpointSupport;
+namespace Newman\LaravelBackscreenApiClient\EndpointSupport;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
 
 class Callback
 {

--- a/src/EndpointSupport/Enums/CallbackHttpMethodEnum.php
+++ b/src/EndpointSupport/Enums/CallbackHttpMethodEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\EndpointSupport\Enums;
+namespace Newman\LaravelBackscreenApiClient\EndpointSupport\Enums;
 
 enum CallbackHttpMethodEnum: string
 {

--- a/src/EndpointSupport/Enums/OrderDirectionEnum.php
+++ b/src/EndpointSupport/Enums/OrderDirectionEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\EndpointSupport\Enums;
+namespace Newman\LaravelBackscreenApiClient\EndpointSupport\Enums;
 
 enum OrderDirectionEnum: string
 {

--- a/src/EndpointSupport/Images.php
+++ b/src/EndpointSupport/Images.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\EndpointSupport;
+namespace Newman\LaravelBackscreenApiClient\EndpointSupport;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Images
 {

--- a/src/Endpoints/Live/Create.php
+++ b/src/Endpoints/Live/Create.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Availability;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Embed;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Input;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Publish;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Recording;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Security;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Input;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Publish;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Recording;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Security;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/Create

--- a/src/Endpoints/Live/Create/Availability.php
+++ b/src/Endpoints/Live/Create/Availability.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
 
 use Carbon\CarbonInterface;
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Availability
 {

--- a/src/Endpoints/Live/Create/Embed.php
+++ b/src/Endpoints/Live/Create/Embed.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Embed
 {

--- a/src/Endpoints/Live/Create/Enums/EncryptionMethodEnum.php
+++ b/src/Endpoints/Live/Create/Enums/EncryptionMethodEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums;
 
 enum EncryptionMethodEnum: string
 {

--- a/src/Endpoints/Live/Create/Enums/ProtocolEnum.php
+++ b/src/Endpoints/Live/Create/Enums/ProtocolEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums;
 
 enum ProtocolEnum: string
 {

--- a/src/Endpoints/Live/Create/Enums/TokenDurationEnum.php
+++ b/src/Endpoints/Live/Create/Enums/TokenDurationEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums;
 
 enum TokenDurationEnum: string
 {

--- a/src/Endpoints/Live/Create/Input/AudioLanguage.php
+++ b/src/Endpoints/Live/Create/Input/AudioLanguage.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class AudioLanguage
 {

--- a/src/Endpoints/Live/Create/Input/Input.php
+++ b/src/Endpoints/Live/Create/Input/Input.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
 
 class Input
 {

--- a/src/Endpoints/Live/Create/Input/Packager.php
+++ b/src/Endpoints/Live/Create/Input/Packager.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Packager
 {

--- a/src/Endpoints/Live/Create/Publish.php
+++ b/src/Endpoints/Live/Create/Publish.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Publish
 {

--- a/src/Endpoints/Live/Create/Recording/EPG.php
+++ b/src/Endpoints/Live/Create/Recording/EPG.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class EPG
 {

--- a/src/Endpoints/Live/Create/Recording/Nimbus.php
+++ b/src/Endpoints/Live/Create/Recording/Nimbus.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Nimbus
 {

--- a/src/Endpoints/Live/Create/Recording/Recording.php
+++ b/src/Endpoints/Live/Create/Recording/Recording.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Recording
 {

--- a/src/Endpoints/Live/Create/Security.php
+++ b/src/Endpoints/Live/Create/Security.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
 
 class Security
 {

--- a/src/Endpoints/Live/Delete.php
+++ b/src/Endpoints/Live/Delete.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/Delete

--- a/src/Endpoints/Live/LiveList.php
+++ b/src/Endpoints/Live/LiveList.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
 use Carbon\CarbonInterface;
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\OrderByEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\PeriodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\ReturnEnum;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\PeriodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\ReturnEnum;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/List

--- a/src/Endpoints/Live/LiveList/OrderByEnum.php
+++ b/src/Endpoints/Live/LiveList/OrderByEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\LiveList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList;
 
 enum OrderByEnum: string
 {

--- a/src/Endpoints/Live/LiveList/PeriodEnum.php
+++ b/src/Endpoints/Live/LiveList/PeriodEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\LiveList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList;
 
 enum PeriodEnum: string
 {

--- a/src/Endpoints/Live/LiveList/ReturnEnum.php
+++ b/src/Endpoints/Live/LiveList/ReturnEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live\LiveList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList;
 
 enum ReturnEnum: string
 {

--- a/src/Endpoints/Live/Off.php
+++ b/src/Endpoints/Live/Off.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/Off

--- a/src/Endpoints/Live/On.php
+++ b/src/Endpoints/Live/On.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/On

--- a/src/Endpoints/Live/Record.php
+++ b/src/Endpoints/Live/Record.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/Record

--- a/src/Endpoints/Live/Update.php
+++ b/src/Endpoints/Live/Update.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Availability;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Embed;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Input;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Publish;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Recording;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Security;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Input;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Publish;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Recording;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Security;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Live/Create

--- a/src/Endpoints/Media/CancelTranscode.php
+++ b/src/Endpoints/Media/CancelTranscode.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Canceltranscode

--- a/src/Endpoints/Media/CloneMedia.php
+++ b/src/Endpoints/Media/CloneMedia.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Clone

--- a/src/Endpoints/Media/Create.php
+++ b/src/Endpoints/Media/Create.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Files;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Tags;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Create

--- a/src/Endpoints/Media/Create/Files.php
+++ b/src/Endpoints/Media/Create/Files.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Files
 {

--- a/src/Endpoints/Media/Create/Tags.php
+++ b/src/Endpoints/Media/Create/Tags.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Create;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class Tags
 {

--- a/src/Endpoints/Media/Delete.php
+++ b/src/Endpoints/Media/Delete.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Delete

--- a/src/Endpoints/Media/GenerateImage.php
+++ b/src/Endpoints/Media/GenerateImage.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Generateimage

--- a/src/Endpoints/Media/Manifest/Create.php
+++ b/src/Endpoints/Media/Manifest/Create.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Manifest/Create

--- a/src/Endpoints/Media/Manifest/CreateUpdateFunctionsTrait.php
+++ b/src/Endpoints/Media/Manifest/CreateUpdateFunctionsTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest;
 
 trait CreateUpdateFunctionsTrait
 {

--- a/src/Endpoints/Media/Manifest/Delete.php
+++ b/src/Endpoints/Media/Manifest/Delete.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Manifest/Delete

--- a/src/Endpoints/Media/Manifest/List/OrderByEnum.php
+++ b/src/Endpoints/Media/Manifest/List/OrderByEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\List;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\List;
 
 enum OrderByEnum: string
 {

--- a/src/Endpoints/Media/Manifest/ManifestList.php
+++ b/src/Endpoints/Media/Manifest/ManifestList.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Manifest/List

--- a/src/Endpoints/Media/Manifest/Update.php
+++ b/src/Endpoints/Media/Manifest/Update.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Manifest/Update

--- a/src/Endpoints/Media/MediaList.php
+++ b/src/Endpoints/Media/MediaList.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
 use Carbon\CarbonInterface;
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList\OrderByEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList\PublisherStatusEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList\StatusEnum;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\PublisherStatusEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\StatusEnum;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 use OutOfBoundsException;
 
 /**

--- a/src/Endpoints/Media/MediaList/OrderByEnum.php
+++ b/src/Endpoints/Media/MediaList/OrderByEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\MediaList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
 
 enum OrderByEnum: string
 {

--- a/src/Endpoints/Media/MediaList/PublisherStatusEnum.php
+++ b/src/Endpoints/Media/MediaList/PublisherStatusEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\MediaList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
 
 enum PublisherStatusEnum: string
 {

--- a/src/Endpoints/Media/MediaList/StatusEnum.php
+++ b/src/Endpoints/Media/MediaList/StatusEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\MediaList;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
 
 enum StatusEnum: string
 {

--- a/src/Endpoints/Media/RegeneratePackages.php
+++ b/src/Endpoints/Media/RegeneratePackages.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Regeneratepackages

--- a/src/Endpoints/Media/Reset.php
+++ b/src/Endpoints/Media/Reset.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Reset

--- a/src/Endpoints/Media/Transcode.php
+++ b/src/Endpoints/Media/Transcode.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Transcode

--- a/src/Endpoints/Media/Trim.php
+++ b/src/Endpoints/Media/Trim.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Trim\TypeEnum;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Trim\TypeEnum;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Trim

--- a/src/Endpoints/Media/Trim/TypeEnum.php
+++ b/src/Endpoints/Media/Trim/TypeEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Trim;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Trim;
 
 enum TypeEnum: string
 {

--- a/src/Endpoints/Media/Update.php
+++ b/src/Endpoints/Media/Update.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\ByContract;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByContract;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Update

--- a/src/Endpoints/Media/Update/ByAssetId.php
+++ b/src/Endpoints/Media/Update/ByAssetId.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Update;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 
 class ByAssetId implements ByContract
 {

--- a/src/Endpoints/Media/Update/ByContract.php
+++ b/src/Endpoints/Media/Update/ByContract.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Update;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 
 interface ByContract
 {

--- a/src/Endpoints/Media/Update/ByMediaId.php
+++ b/src/Endpoints/Media/Update/ByMediaId.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Update;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 
 class ByMediaId implements ByContract
 {

--- a/src/Endpoints/Media/Update/Images.php
+++ b/src/Endpoints/Media/Update/Images.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media\Update;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 
-use Newman\LaravelTmsApiClient\EndpointSupport\Images as BaseImages;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as BaseImages;
 
 class Images extends BaseImages
 {

--- a/src/Endpoints/Media/UpdateSubtitlesFromSource.php
+++ b/src/Endpoints/Media/UpdateSubtitlesFromSource.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Media/Updatesubtitlesfromsource

--- a/src/Endpoints/Token/Generate.php
+++ b/src/Endpoints/Token/Generate.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Token;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Token;
 
 use Carbon\CarbonInterface;
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Token\Generate\ItemTypeEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Token\Generate\SubitemTypeEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate\ItemTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate\SubitemTypeEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/Token/Generate

--- a/src/Endpoints/Token/Generate/ItemTypeEnum.php
+++ b/src/Endpoints/Token/Generate/ItemTypeEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Token\Generate;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate;
 
 enum ItemTypeEnum: string
 {

--- a/src/Endpoints/Token/Generate/SubitemTypeEnum.php
+++ b/src/Endpoints/Token/Generate/SubitemTypeEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\Token\Generate;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate;
 
 enum SubitemTypeEnum: string
 {

--- a/src/Endpoints/User/Get.php
+++ b/src/Endpoints/User/Get.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/User/Get

--- a/src/Endpoints/User/Login.php
+++ b/src/Endpoints/User/Login.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/User/Login

--- a/src/Endpoints/User/Logout.php
+++ b/src/Endpoints/User/Logout.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
 
 /**
  * @link https://api.cloudycdn.services/api/v5/docs#/operations/User/Logout

--- a/src/Enums/AuthMethodEnum.php
+++ b/src/Enums/AuthMethodEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Enums;
+namespace Newman\LaravelBackscreenApiClient\Enums;
 
 enum AuthMethodEnum
 {

--- a/src/Enums/HttpMethodEnum.php
+++ b/src/Enums/HttpMethodEnum.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Enums;
+namespace Newman\LaravelBackscreenApiClient\Enums;
 
 enum HttpMethodEnum: string
 {

--- a/src/Exceptions/InvalidTmsApiClientException.php
+++ b/src/Exceptions/InvalidTmsApiClientException.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Exceptions;
+namespace Newman\LaravelBackscreenApiClient\Exceptions;
 
 class InvalidTmsApiClientException extends \InvalidArgumentException {}

--- a/src/Exceptions/TmsAuthMethodNotAllowed.php
+++ b/src/Exceptions/TmsAuthMethodNotAllowed.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Exceptions;
+namespace Newman\LaravelBackscreenApiClient\Exceptions;
 
 class TmsAuthMethodNotAllowed extends \RuntimeException {}

--- a/src/HttpClient/HttpFactory.php
+++ b/src/HttpClient/HttpFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\HttpClient;
+namespace Newman\LaravelBackscreenApiClient\HttpClient;
 
 use Illuminate\Http\Client\Factory;
 

--- a/src/HttpClient/PendingRequest.php
+++ b/src/HttpClient/PendingRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\HttpClient;
+namespace Newman\LaravelBackscreenApiClient\HttpClient;
 
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
 
 class PendingRequest extends \Illuminate\Http\Client\PendingRequest
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient;
+namespace Newman\LaravelBackscreenApiClient;
 
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Contracts\TmsApiContract;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Contracts\TmsApiContract;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -22,7 +22,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function register(): void
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/tms-api.php', 'tms-api');
+        $this->mergeConfigFrom(__DIR__.'/../config/backscreen-api.php', 'backscreen-api');
 
         $this->app->singleton(TmsApiContract::class, TmsApi::class);
         $this->app->singleton(ClientContract::class, Client::class);
@@ -35,8 +35,8 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/tms-api.php' => config_path('tms-api.php'),
-            ], 'tms-api-config');
+                __DIR__.'/../config/backscreen-api.php' => config_path('backscreen-api.php'),
+            ], 'backscreen-api-config');
         }
     }
 }

--- a/src/Support/Facades/TmsApi.php
+++ b/src/Support/Facades/TmsApi.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Support\Facades;
+namespace Newman\LaravelBackscreenApiClient\Support\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Contracts\TmsApiContract;
-use Newman\LaravelTmsApiClient\Support\TmsApiFake;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Contracts\TmsApiContract;
+use Newman\LaravelBackscreenApiClient\Support\TmsApiFake;
 
 /**
  * @method static ClientContract client(string $name)

--- a/src/Support/TmsApiFake.php
+++ b/src/Support/TmsApiFake.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Support;
+namespace Newman\LaravelBackscreenApiClient\Support;
 
-use Newman\LaravelTmsApiClient\Contracts\TmsApiContract;
+use Newman\LaravelBackscreenApiClient\Contracts\TmsApiContract;
 
 class TmsApiFake
 {

--- a/src/TmsApi.php
+++ b/src/TmsApi.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient;
+namespace Newman\LaravelBackscreenApiClient;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
-use Newman\LaravelTmsApiClient\Auth\BasicAuthMethod;
-use Newman\LaravelTmsApiClient\Auth\NullAuthMethod;
-use Newman\LaravelTmsApiClient\Contracts\AuthMethodContract;
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Contracts\TmsApiContract;
-use Newman\LaravelTmsApiClient\Exceptions\InvalidTmsApiClientException;
+use Newman\LaravelBackscreenApiClient\Auth\BasicAuthMethod;
+use Newman\LaravelBackscreenApiClient\Auth\NullAuthMethod;
+use Newman\LaravelBackscreenApiClient\Contracts\AuthMethodContract;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Contracts\TmsApiContract;
+use Newman\LaravelBackscreenApiClient\Exceptions\InvalidTmsApiClientException;
 
 class TmsApi implements TmsApiContract
 {

--- a/tests/EndpointSupport/ImagesTest.php
+++ b/tests/EndpointSupport/ImagesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\EndpointSupport;
+namespace Newman\LaravelBackscreenApiClient\Tests\EndpointSupport;
 
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class ImagesTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/AvailabilityTest.php
+++ b/tests/Endpoints/Live/Create/AvailabilityTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Availability;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class AvailabilityTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/EmbedTest.php
+++ b/tests/Endpoints/Live/Create/EmbedTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Embed;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class EmbedTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/Input/AudioLanguageTest.php
+++ b/tests/Endpoints/Live/Create/Input/AudioLanguageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create\Input;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\AudioLanguage;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\AudioLanguage;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class AudioLanguageTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/InputTest.php
+++ b/tests/Endpoints/Live/Create/InputTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\AudioLanguage;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Input;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Packager;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\AudioLanguage;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Input;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Packager;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class InputTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/PublishTest.php
+++ b/tests/Endpoints/Live/Create/PublishTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Publish;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Publish;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class PublishTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/Recording/EPGTest.php
+++ b/tests/Endpoints/Live/Create/Recording/EPGTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create\Recording;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\EPG;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\EPG;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class EPGTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/Recording/NimbusTest.php
+++ b/tests/Endpoints/Live/Create/Recording/NimbusTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create\Recording;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Nimbus;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Nimbus;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class NimbusTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/RecordingTest.php
+++ b/tests/Endpoints/Live/Create/RecordingTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\EPG;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Nimbus;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Recording;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\EPG;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Nimbus;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Recording;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class RecordingTest extends TestCase
 {

--- a/tests/Endpoints/Live/Create/SecurityTest.php
+++ b/tests/Endpoints/Live/Create/SecurityTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live\Create;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live\Create;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Security;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Security;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class SecurityTest extends TestCase
 {

--- a/tests/Endpoints/Live/CreateTest.php
+++ b/tests/Endpoints/Live/CreateTest.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Availability;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Embed;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\AudioLanguage;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Input;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Packager;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Publish;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\EPG;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Nimbus;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Recording;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Security;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\AudioLanguage;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Input;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Packager;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Publish;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\EPG;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Nimbus;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Recording;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Security;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class CreateTest extends TestCase
 {

--- a/tests/Endpoints/Live/DeleteTest.php
+++ b/tests/Endpoints/Live/DeleteTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Delete;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Delete;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class DeleteTest extends TestCase
 {

--- a/tests/Endpoints/Live/LiveListTest.php
+++ b/tests/Endpoints/Live/LiveListTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\OrderByEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\PeriodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\LiveList\ReturnEnum;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\PeriodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\LiveList\ReturnEnum;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class LiveListTest extends TestCase
 {

--- a/tests/Endpoints/Live/OffTest.php
+++ b/tests/Endpoints/Live/OffTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Off;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Off;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class OffTest extends TestCase
 {

--- a/tests/Endpoints/Live/OnTest.php
+++ b/tests/Endpoints/Live/OnTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\On;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\On;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class OnTest extends TestCase
 {

--- a/tests/Endpoints/Live/RecordTest.php
+++ b/tests/Endpoints/Live/RecordTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
-use Newman\LaravelTmsApiClient\Endpoints\Live\Record;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Record;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class RecordTest extends TestCase
 {

--- a/tests/Endpoints/Live/UpdateTest.php
+++ b/tests/Endpoints/Live/UpdateTest.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Live;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Live;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Availability;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Embed;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\AudioLanguage;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Input;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Input\Packager;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Publish;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\EPG;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Nimbus;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Recording\Recording;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Create\Security;
-use Newman\LaravelTmsApiClient\Endpoints\Live\Update;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Enums\TokenDurationEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\AudioLanguage;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Input;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Input\Packager;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Publish;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\EPG;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Nimbus;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Recording\Recording;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Create\Security;
+use Newman\LaravelBackscreenApiClient\Endpoints\Live\Update;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class UpdateTest extends TestCase
 {

--- a/tests/Endpoints/Media/CancelTranscodeTest.php
+++ b/tests/Endpoints/Media/CancelTranscodeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\CancelTranscode;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\CancelTranscode;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class CancelTranscodeTest extends TestCase
 {

--- a/tests/Endpoints/Media/CloneMediaTest.php
+++ b/tests/Endpoints/Media/CloneMediaTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\CloneMedia;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\CloneMedia;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class CloneMediaTest extends TestCase
 {

--- a/tests/Endpoints/Media/CreateTest.php
+++ b/tests/Endpoints/Media/CreateTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Files;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Create\Tags;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class CreateTest extends TestCase
 {

--- a/tests/Endpoints/Media/DeleteTest.php
+++ b/tests/Endpoints/Media/DeleteTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Delete;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Delete;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class DeleteTest extends TestCase
 {

--- a/tests/Endpoints/Media/GenerateImageTest.php
+++ b/tests/Endpoints/Media/GenerateImageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\GenerateImage;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\GenerateImage;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class GenerateImageTest extends TestCase
 {

--- a/tests/Endpoints/Media/Manifest/CreateTest.php
+++ b/tests/Endpoints/Media/Manifest/CreateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Create;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Create;
 
 class CreateTest extends ManifestCreateAndUpdateTestCase
 {

--- a/tests/Endpoints/Media/Manifest/DeleteTest.php
+++ b/tests/Endpoints/Media/Manifest/DeleteTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Delete;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Delete;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class DeleteTest extends TestCase
 {

--- a/tests/Endpoints/Media/Manifest/ManifestCreateAndUpdateTestCase.php
+++ b/tests/Endpoints/Media/Manifest/ManifestCreateAndUpdateTestCase.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 abstract class ManifestCreateAndUpdateTestCase extends TestCase
 {

--- a/tests/Endpoints/Media/Manifest/ManifestListTest.php
+++ b/tests/Endpoints/Media/Manifest/ManifestListTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\ManifestList;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\List\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\ManifestList;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class ManifestListTest extends TestCase
 {

--- a/tests/Endpoints/Media/Manifest/UpdateTest.php
+++ b/tests/Endpoints/Media/Manifest/UpdateTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Manifest;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Manifest;
 
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Manifest\Update;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Manifest\Update;
 
 class UpdateTest extends ManifestCreateAndUpdateTestCase
 {

--- a/tests/Endpoints/Media/MediaListTest.php
+++ b/tests/Endpoints/Media/MediaListTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\OrderDirectionEnum;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class MediaListTest extends TestCase
 {

--- a/tests/Endpoints/Media/RegeneratePackagesTest.php
+++ b/tests/Endpoints/Media/RegeneratePackagesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\RegeneratePackages;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\RegeneratePackages;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class RegeneratePackagesTest extends TestCase
 {

--- a/tests/Endpoints/Media/ResetTest.php
+++ b/tests/Endpoints/Media/ResetTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Reset;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Reset;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class ResetTest extends TestCase
 {

--- a/tests/Endpoints/Media/TranscodeTest.php
+++ b/tests/Endpoints/Media/TranscodeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Transcode;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Transcode;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class TranscodeTest extends TestCase
 {

--- a/tests/Endpoints/Media/TrimTest.php
+++ b/tests/Endpoints/Media/TrimTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Trim;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Trim;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class TrimTest extends TestCase
 {

--- a/tests/Endpoints/Media/Update/ImagesTest.php
+++ b/tests/Endpoints/Media/Update/ImagesTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media\Update;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Update;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\Images;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Images;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class ImagesTest extends TestCase
 {

--- a/tests/Endpoints/Media/UpdateSubtitlesFromSourceTest.php
+++ b/tests/Endpoints/Media/UpdateSubtitlesFromSourceTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\UpdateSubtitlesFromSource;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UpdateSubtitlesFromSource;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class UpdateSubtitlesFromSourceTest extends TestCase
 {

--- a/tests/Endpoints/Media/UpdateTest.php
+++ b/tests/Endpoints/Media/UpdateTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Media;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\ByAssetId;
-use Newman\LaravelTmsApiClient\Endpoints\Media\Update\ByMediaId;
-use Newman\LaravelTmsApiClient\EndpointSupport\Callback;
-use Newman\LaravelTmsApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelTmsApiClient\EndpointSupport\Images;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByAssetId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByMediaId;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class UpdateTest extends TestCase
 {

--- a/tests/Endpoints/TestCase.php
+++ b/tests/Endpoints/TestCase.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints;
 
 use Illuminate\Http\Client\Response;
-use Newman\LaravelTmsApiClient\Auth\ApiKeyAuthMethod;
-use Newman\LaravelTmsApiClient\Auth\BasicAuthMethod;
-use Newman\LaravelTmsApiClient\Auth\BearerAuthMethod;
-use Newman\LaravelTmsApiClient\Auth\NullAuthMethod;
-use Newman\LaravelTmsApiClient\Client;
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Auth\ApiKeyAuthMethod;
+use Newman\LaravelBackscreenApiClient\Auth\BasicAuthMethod;
+use Newman\LaravelBackscreenApiClient\Auth\BearerAuthMethod;
+use Newman\LaravelBackscreenApiClient\Auth\NullAuthMethod;
+use Newman\LaravelBackscreenApiClient\Client;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
 
-abstract class TestCase extends \Newman\LaravelTmsApiClient\Tests\TestCase
+abstract class TestCase extends \Newman\LaravelBackscreenApiClient\Tests\TestCase
 {
     protected function makeBasicAuthEndpointTest(EndpointContract $endpoint, array $query = [], array|string|null $body = null, ?array $fakeResponse = null): Response
     {

--- a/tests/Endpoints/Token/GenerateTest.php
+++ b/tests/Endpoints/Token/GenerateTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\Token;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Token;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Endpoints\Token\Generate;
-use Newman\LaravelTmsApiClient\Endpoints\Token\Generate\SubitemTypeEnum;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate;
+use Newman\LaravelBackscreenApiClient\Endpoints\Token\Generate\SubitemTypeEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class GenerateTest extends TestCase
 {

--- a/tests/Endpoints/User/GetTest.php
+++ b/tests/Endpoints/User/GetTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\Endpoints\User\Get;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Get;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class GetTest extends TestCase
 {

--- a/tests/Endpoints/User/LoginTest.php
+++ b/tests/Endpoints/User/LoginTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\Endpoints\User\Login;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Login;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class LoginTest extends TestCase
 {

--- a/tests/Endpoints/User/LogoutTest.php
+++ b/tests/Endpoints/User/LogoutTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Endpoints\User;
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\User;
 
-use Newman\LaravelTmsApiClient\Endpoints\User\Logout;
-use Newman\LaravelTmsApiClient\Tests\Endpoints\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\User\Logout;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class LogoutTest extends TestCase
 {

--- a/tests/Support/GetTestEndpoint.php
+++ b/tests/Support/GetTestEndpoint.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Support;
+namespace Newman\LaravelBackscreenApiClient\Tests\Support;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class GetTestEndpoint extends AbstractEndpoint implements EndpointContract
 {

--- a/tests/Support/PostTestBearerOnlyEndpoint.php
+++ b/tests/Support/PostTestBearerOnlyEndpoint.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Support;
+namespace Newman\LaravelBackscreenApiClient\Tests\Support;
 
-use Newman\LaravelTmsApiClient\AbstractEndpoint;
-use Newman\LaravelTmsApiClient\Contracts\EndpointContract;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
 class PostTestBearerOnlyEndpoint extends AbstractEndpoint implements EndpointContract
 {

--- a/tests/Support/TestClassWithProperties.php
+++ b/tests/Support/TestClassWithProperties.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Support;
+namespace Newman\LaravelBackscreenApiClient\Tests\Support;
 
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
 
 class TestClassWithProperties
 {

--- a/tests/Support/TestClassWithPropertiesAndExceptProperties.php
+++ b/tests/Support/TestClassWithPropertiesAndExceptProperties.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Support;
+namespace Newman\LaravelBackscreenApiClient\Tests\Support;
 
 use Carbon\Carbon;
-use Newman\LaravelTmsApiClient\Concerns\CompilesProperties;
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList\StatusEnum;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\StatusEnum;
 
 class TestClassWithPropertiesAndExceptProperties
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests;
+namespace Newman\LaravelBackscreenApiClient\Tests;
 
-use Newman\LaravelTmsApiClient\ServiceProvider;
+use Newman\LaravelBackscreenApiClient\ServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra

--- a/tests/Unit/Auth/ApiKeyAuthMethodTest.php
+++ b/tests/Unit/Auth/ApiKeyAuthMethodTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit\Auth;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit\Auth;
 
-use Newman\LaravelTmsApiClient\Auth\ApiKeyAuthMethod;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Auth\ApiKeyAuthMethod;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class ApiKeyAuthMethodTest extends TestCase
 {

--- a/tests/Unit/Auth/BasicAuthMethodTest.php
+++ b/tests/Unit/Auth/BasicAuthMethodTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit\Auth;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit\Auth;
 
 use Illuminate\Support\Arr;
-use Newman\LaravelTmsApiClient\Auth\BasicAuthMethod;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Auth\BasicAuthMethod;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class BasicAuthMethodTest extends TestCase
 {

--- a/tests/Unit/Auth/BearerAuthMethodTest.php
+++ b/tests/Unit/Auth/BearerAuthMethodTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit\Auth;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit\Auth;
 
 use Illuminate\Support\Arr;
-use Newman\LaravelTmsApiClient\Auth\BearerAuthMethod;
-use Newman\LaravelTmsApiClient\Enums\AuthMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Auth\BearerAuthMethod;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class BearerAuthMethodTest extends TestCase
 {

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit;
 
 use GuzzleHttp\Middleware;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Arr;
-use Newman\LaravelTmsApiClient\Auth\BasicAuthMethod;
-use Newman\LaravelTmsApiClient\Auth\BearerAuthMethod;
-use Newman\LaravelTmsApiClient\Client;
-use Newman\LaravelTmsApiClient\Exceptions\TmsAuthMethodNotAllowed;
-use Newman\LaravelTmsApiClient\Tests\Support\GetTestEndpoint;
-use Newman\LaravelTmsApiClient\Tests\Support\PostTestBearerOnlyEndpoint;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Auth\BasicAuthMethod;
+use Newman\LaravelBackscreenApiClient\Auth\BearerAuthMethod;
+use Newman\LaravelBackscreenApiClient\Client;
+use Newman\LaravelBackscreenApiClient\Exceptions\TmsAuthMethodNotAllowed;
+use Newman\LaravelBackscreenApiClient\Tests\Support\GetTestEndpoint;
+use Newman\LaravelBackscreenApiClient\Tests\Support\PostTestBearerOnlyEndpoint;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 class ClientTest extends TestCase

--- a/tests/Unit/Concerns/CompilesPropertiesConcernTest.php
+++ b/tests/Unit/Concerns/CompilesPropertiesConcernTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit\Concerns;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit\Concerns;
 
-use Newman\LaravelTmsApiClient\Endpoints\Media\MediaList\StatusEnum;
-use Newman\LaravelTmsApiClient\Tests\Support\TestClassWithProperties;
-use Newman\LaravelTmsApiClient\Tests\Support\TestClassWithPropertiesAndExceptProperties;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\StatusEnum;
+use Newman\LaravelBackscreenApiClient\Tests\Support\TestClassWithProperties;
+use Newman\LaravelBackscreenApiClient\Tests\Support\TestClassWithPropertiesAndExceptProperties;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class CompilesPropertiesConcernTest extends TestCase
 {

--- a/tests/Unit/PendingRequestTest.php
+++ b/tests/Unit/PendingRequestTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit;
 
-use Newman\LaravelTmsApiClient\Enums\HttpMethodEnum;
-use Newman\LaravelTmsApiClient\HttpClient\HttpFactory;
-use Newman\LaravelTmsApiClient\HttpClient\PendingRequest;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\HttpFactory;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class PendingRequestTest extends TestCase
 {

--- a/tests/Unit/TmsApiTest.php
+++ b/tests/Unit/TmsApiTest.php
@@ -2,19 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Newman\LaravelTmsApiClient\Tests\Unit;
+namespace Newman\LaravelBackscreenApiClient\Tests\Unit;
 
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Http;
-use Newman\LaravelTmsApiClient\Auth\ApiKeyAuthMethod;
-use Newman\LaravelTmsApiClient\Client;
-use Newman\LaravelTmsApiClient\Contracts\ClientContract;
-use Newman\LaravelTmsApiClient\Exceptions\InvalidTmsApiClientException;
-use Newman\LaravelTmsApiClient\Support\Facades\TmsApi;
-use Newman\LaravelTmsApiClient\Tests\Support\GetTestEndpoint;
-use Newman\LaravelTmsApiClient\Tests\TestCase;
+use Newman\LaravelBackscreenApiClient\Auth\ApiKeyAuthMethod;
+use Newman\LaravelBackscreenApiClient\Client;
+use Newman\LaravelBackscreenApiClient\Contracts\ClientContract;
+use Newman\LaravelBackscreenApiClient\Exceptions\InvalidTmsApiClientException;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Tests\Support\GetTestEndpoint;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
 
 class TmsApiTest extends TestCase
 {


### PR DESCRIPTION
- [x] Breaking change

Naming from keyword `tms` was replaced with `backscreen` presenting the most accurate current naming of the service, resulting:
- Namespace changed from `Newman\LaravelTmsApiClient` to `Newman\LaravelBackscreenApiClient`
- Config file renamed from `tms-api.php` to `backscreen-api.php`

Composer package name currently leaves the same and is the last place where old naming is still in use. Probably will be renamed in 3.x