### PR TITLE
Media/* Endpoint update to be in-line with Backscreen API documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,16 @@ Create media.
 
 ```php
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create as MediaCreate;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\TokenDurationEnum;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
 $endpoint = new MediaCreate('123');
 
@@ -243,24 +248,47 @@ $endpoint->autoTranscode(1);
 $endpoint->embedPlayerId(123);
 $endpoint->embedAdId(234);
 $endpoint->embedProtectionId(345);
-$endpoint->metadata([
-    'key' => 'value'
-]);
+$endpoint->metadata(['key' => 'value']);
 $endpoint->timezone('Europe/Riga');
 
-$files = new MediaCreate\Files();
+$files = new Files();
 $files->url('https://mysite.com');
 $files->username('username');
 $files->password('secret');
 $files->bitrate(3000);
 $files->lang('LV');
-$endpoint->files($files);
+$endpoint->files([$files]); // accepts array of Files objects
 
-$tags = new MediaCreate\Tags();
+$tags = new Tags();
 $tags->set(['tag1', 'tag2']);
 $tags->add(['tag3']);
+$endpoint->tags($tags);
 
-$endpoint->callback(new Callback('https://mysite.com', CallbackHttpMethodEnum::POST));
+$images = new Images();
+$images->thumbnail(base64_encode('THUMBNAIL_CONTENTS'));
+$images->placeholder(base64_encode('PLACEHOLDER_CONTENTS'));
+$endpoint->images($images);
+
+$embed = new Embed();
+$embed->enablePublic(1);
+$embed->publicPassword('password');
+$embed->enablePreview(1);
+$endpoint->embed($embed);
+
+$security = new Security();
+$security->encryptionMethod(EncryptionMethodEnum::AES);
+$security->useToken(1);
+$security->tokenDuration(TokenDurationEnum::ONE_HOUR);
+$endpoint->security($security);
+
+$availability = new Availability();
+$availability->published(1);
+$availability->expireTime('2026-12-31 23:59:59');
+$endpoint->availability($availability);
+
+$transcodeInfo = new TranscodeInfo();
+$transcodeInfo->presetId(10);
+$endpoint->transcodeInfo($transcodeInfo);
 
 $response = TmsApi::client('default')->run($endpoint);
 ```
@@ -274,31 +302,86 @@ Update media.
 **Accepted Auth Methods:** `Basic`, `Bearer token`, `API Key`
 
 ```php
-use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update as MediaUpdate;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
-use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByMediaId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update as MediaUpdate;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByAssetId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByMediaId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Tags;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\UpdateManifest;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
 
-// Select by which identificator to update
+// Select by which identifier to update
 // by media ID
 $endpoint = new MediaUpdate(new ByMediaId(123));
 // by asset ID
 $endpoint = new MediaUpdate(new ByAssetId('99_asset_id'));
 
 // Optional
+$endpoint->catId(542);
 $endpoint->name('Name of media');
 $endpoint->description('Description of media');
+$endpoint->pgRating('PG-13');
+$endpoint->autoTranscode(1);
+$endpoint->embedPlayerId(123);
+$endpoint->embedAdId(234);
+$endpoint->embedProtectionId(345);
+$endpoint->metadata(['key' => 'value']);
+$endpoint->timezone('Europe/Riga');
 
-$images = new MediaUpdate\Images();
-$images->thumbnail('thumbnail base64');
-$images->placeholder('placeholder base64');
-$images->playbutton('playbutton base64');
-$images->logo('logo base64');
+$files = new Files();
+$files->url('https://mysite.com');
+$files->username('username');
+$files->password('secret');
+$files->bitrate(3000);
+$files->lang('LV');
+$endpoint->files([$files]); // accepts array of Files objects
+
+$images = new Images();
+$images->thumbnail(base64_encode('THUMBNAIL_CONTENTS'));
+$images->placeholder(base64_encode('PLACEHOLDER_CONTENTS'));
 $endpoint->images($images);
 
-$endpoint->callback(new Callback('https://mysite.com', CallbackHttpMethodEnum::POST));
+$embed = new Embed();
+$embed->enablePublic(1);
+$embed->publicPassword('password');
+$embed->enablePreview(1);
+$endpoint->embed($embed);
+
+$security = new Security();
+$security->encryptionMethod(EncryptionMethodEnum::AES);
+$security->useToken(1);
+$endpoint->security($security);
+
+$availability = new Availability();
+$availability->published(1);
+$availability->expireTime('2026-12-31 23:59:59');
+$endpoint->availability($availability);
+
+$transcodeInfo = new TranscodeInfo();
+$transcodeInfo->presetId(10);
+$endpoint->transcodeInfo($transcodeInfo);
+
+$tags = new Tags();
+$tags->set(['tag1', 'tag2']);
+$tags->add(['tag3']);
+$tags->remove(['tag4']);
+$endpoint->tags($tags);
+
+$manifest = new UpdateManifest();
+$manifest->id(85291);
+$manifest->startAt(1000);
+$manifest->endAt(60000);
+$endpoint->updateManifests([$manifest]);
+
+$endpoint->callback([new Callback('https://mysite.com', CallbackHttpMethodEnum::POST)]);
 
 $response = TmsApi::client('default')->run($endpoint);
 ```
@@ -450,6 +533,89 @@ $endpoint = new RegeneratePackages(1234);
 
 // Optional
 $endpoint->packageId([10, 15]);
+
+$response = TmsApi::client('default')->run($endpoint);
+```
+
+### Endpoint: `/Media/Publish`
+
+https://api.cloudycdn.services/api/v5/docs#/operations/Media/Publish
+
+Publish or unpublish media by ID/s.
+
+**Accepted Auth Methods:** `Bearer token`
+
+```php
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Publish as MediaPublish;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+
+// Publish a single media item (1 = publish, 0 = unpublish)
+$endpoint = new MediaPublish(1234, 1);
+
+// Publish multiple media items
+$endpoint = new MediaPublish([1234, 5678], 1);
+
+$response = TmsApi::client('default')->run($endpoint);
+```
+
+### Endpoint: `/Media/Uploadtoexternal`
+
+https://api.cloudycdn.services/api/v5/docs#/operations/Media/Uploadtoexternal
+
+Upload media files to an external destination.
+
+**Accepted Auth Methods:** `Bearer token`
+
+```php
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal as MediaUploadToExternal;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\CustomFile;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\PackageFile;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+
+// Single media ID and upload destination ID
+$endpoint = new MediaUploadToExternal(1234, 10);
+
+// Multiple media IDs
+$endpoint = new MediaUploadToExternal([1234, 5678], 10);
+
+// Optional
+$endpoint->path('/uploads/');
+$endpoint->catDir(1);  // 0 or 1
+$endpoint->assetDir(1); // 0 or 1
+
+$endpoint->packageFiles([
+    new PackageFile(package_id: 4020, file_id: 582),
+]);
+
+$endpoint->customFiles([
+    new CustomFile(file_id: 900, filename: 'custom_file.mp4'),
+]);
+
+$response = TmsApi::client('default')->run($endpoint);
+```
+
+### Endpoint: `/Media/Validate`
+
+https://api.cloudycdn.services/api/v5/docs#/operations/Media/Validate
+
+Validate media by ID/s.
+
+**Accepted Auth Methods:** `Bearer token`
+
+```php
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Validate as MediaValidate;
+use Newman\LaravelBackscreenApiClient\Support\Facades\TmsApi;
+
+// Single ID
+$endpoint = new MediaValidate(1234);
+
+// Multiple IDs
+$endpoint = new MediaValidate([1234, 5678]);
+
+// Optional
+$endpoint->transcode(1);          // 0 or 1
+$endpoint->transcodePriority(1);  // 0 = normal, 1 = top priority
+$endpoint->transcodingPresetId(10);
 
 $response = TmsApi::client('default')->run($endpoint);
 ```

--- a/src/EndpointSupport/Images.php
+++ b/src/EndpointSupport/Images.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Newman\LaravelBackscreenApiClient\EndpointSupport;
 
 use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Support\ValidateImage;
 
 class Images
 {
@@ -20,7 +21,7 @@ class Images
 
     public function thumbnail(?string $imageBase64): static
     {
-        if (! $this->verifyBase64Encoded($imageBase64)) {
+        if (! ValidateImage::verify($imageBase64)) {
             throw new \InvalidArgumentException('thumbnail must be a base64 encoded string');
         }
 
@@ -31,7 +32,7 @@ class Images
 
     public function placeholder(?string $imageBase64): static
     {
-        if (! $this->verifyBase64Encoded($imageBase64)) {
+        if (! ValidateImage::verify($imageBase64)) {
             throw new \InvalidArgumentException('placeholder must be a base64 encoded string');
         }
 
@@ -42,7 +43,7 @@ class Images
 
     public function playbutton(?string $imageBase64): static
     {
-        if (! $this->verifyBase64Encoded($imageBase64)) {
+        if (! ValidateImage::verify($imageBase64)) {
             throw new \InvalidArgumentException('playbutton must be a base64 encoded string');
         }
 
@@ -53,33 +54,12 @@ class Images
 
     public function logo(?string $imageBase64): static
     {
-        if (! $this->verifyBase64Encoded($imageBase64)) {
+        if (! ValidateImage::verify($imageBase64)) {
             throw new \InvalidArgumentException('logo must be a base64 encoded string');
         }
 
         $this->logo = $imageBase64;
 
         return $this;
-    }
-
-    private function verifyBase64Encoded(?string $value): bool
-    {
-        if ($value === null) {
-            return false;
-        }
-
-        if (! str_contains($value, 'data:') || ! str_contains($value, 'base64,')) {
-            return false;
-        }
-
-        $base64 = substr($value, strpos($value, 'base64,') + strlen('base64,'));
-
-        $decoded = base64_decode($base64, true);
-
-        if ($decoded === false) {
-            return false;
-        }
-
-        return base64_encode($decoded) === $base64;
     }
 }

--- a/src/Endpoints/Media/Create.php
+++ b/src/Endpoints/Media/Create.php
@@ -6,9 +6,16 @@ namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
 use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
 use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Embed;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Player;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Presentation;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as LegacyImages;
 use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
 use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
 use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
@@ -36,6 +43,23 @@ class Create extends AbstractEndpoint implements EndpointContract
 
     protected ?int $embed_protection_id = null;
 
+    protected ?TranscodeInfo $transcode_info = null;
+
+    protected ?Images $images = null;
+
+    protected ?Embed $embed = null;
+
+    protected ?Presentation $presentation = null;
+
+    protected ?Player $player = null;
+
+    /** @var Files[]|null */
+    protected ?array $files = null;
+
+    protected ?Security $security = null;
+
+    protected ?Availability $availability = null;
+
     /**
      * @var array<mixed>|null
      */
@@ -43,13 +67,7 @@ class Create extends AbstractEndpoint implements EndpointContract
 
     protected ?string $timezone = null;
 
-    /** @var Files[]|null */
-    protected ?array $files = null;
-
     protected ?Tags $tags = null;
-
-    /** @var Callback[]|null */
-    protected ?array $callback = null;
 
     public function __construct(string $asset_id)
     {
@@ -91,6 +109,9 @@ class Create extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * Allowed values: 0 or 1.
+     */
     public function autoTranscode(?int $auto_transcode): static
     {
         $this->auto_transcode = $auto_transcode;
@@ -98,6 +119,9 @@ class Create extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
     public function embedPlayerId(?int $embed_player_id): static
     {
         $this->embed_player_id = $embed_player_id;
@@ -105,6 +129,9 @@ class Create extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
     public function embedAdId(?int $embed_ad_id): static
     {
         $this->embed_ad_id = $embed_ad_id;
@@ -112,9 +139,73 @@ class Create extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
     public function embedProtectionId(?int $embed_protection_id): static
     {
         $this->embed_protection_id = $embed_protection_id;
+
+        return $this;
+    }
+
+    public function transcodeInfo(?TranscodeInfo $transcode_info): static
+    {
+        $this->transcode_info = $transcode_info;
+
+        return $this;
+    }
+
+    public function images(Images|LegacyImages|null $images): static
+    {
+        if ($images instanceof LegacyImages) {
+            /** @var array{thumbnail?: string, placeholder?: string} $compiled */
+            $compiled = $images->compileAsArray();
+            $images = new Images;
+            if (isset($compiled['thumbnail'])) {
+                $images->thumbnail($compiled['thumbnail']);
+            }
+            if (isset($compiled['placeholder'])) {
+                $images->placeholder($compiled['placeholder']);
+            }
+        }
+
+        $this->images = $images;
+
+        return $this;
+    }
+
+    public function embed(?Embed $embed): static
+    {
+        $this->embed = $embed;
+
+        return $this;
+    }
+
+    public function presentation(?Presentation $presentation): static
+    {
+        $this->presentation = $presentation;
+
+        return $this;
+    }
+
+    public function player(?Player $player): static
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+
+    public function security(?Security $security): static
+    {
+        $this->security = $security;
+
+        return $this;
+    }
+
+    public function availability(?Availability $availability): static
+    {
+        $this->availability = $availability;
 
         return $this;
     }
@@ -149,16 +240,6 @@ class Create extends AbstractEndpoint implements EndpointContract
     public function tags(?Tags $tags): static
     {
         $this->tags = $tags;
-
-        return $this;
-    }
-
-    /**
-     * @param  Callback[]|null  $callback
-     */
-    public function callback(?array $callback): static
-    {
-        $this->callback = $callback;
 
         return $this;
     }
@@ -230,6 +311,62 @@ class Create extends AbstractEndpoint implements EndpointContract
             $data['embed_protection_id'] = $this->embed_protection_id;
         }
 
+        if ($this->transcode_info !== null) {
+            $transcode_info = $this->transcode_info->compileAsArray();
+
+            if (! empty($transcode_info)) {
+                $data['transcode_info'] = $transcode_info;
+            }
+        }
+
+        if ($this->images !== null) {
+            $images = $this->images->compileAsArray();
+
+            if (! empty($images)) {
+                $data['images'] = $images;
+            }
+        }
+
+        if ($this->embed !== null) {
+            $embed = $this->embed->compileAsArray();
+
+            if (! empty($embed)) {
+                $data['embed'] = $embed;
+            }
+        }
+
+        if ($this->presentation !== null) {
+            $presentation = $this->presentation->compileAsArray();
+
+            if (! empty($presentation)) {
+                $data['presentation'] = $presentation;
+            }
+        }
+
+        if ($this->player !== null) {
+            $player = $this->player->compileAsArray();
+
+            if (! empty($player)) {
+                $data['player'] = $player;
+            }
+        }
+
+        if ($this->security !== null) {
+            $security = $this->security->compileAsArray();
+
+            if (! empty($security)) {
+                $data['security'] = $security;
+            }
+        }
+
+        if ($this->availability !== null) {
+            $availability = $this->availability->compileAsArray();
+
+            if (! empty($availability)) {
+                $data['availability'] = $availability;
+            }
+        }
+
         if ($this->metadata !== null) {
             $data['metadata'] = $this->metadata;
         }
@@ -258,21 +395,6 @@ class Create extends AbstractEndpoint implements EndpointContract
 
             if (! empty($tags)) {
                 $data['tags'] = $tags;
-            }
-        }
-
-        if ($this->callback !== null) {
-            $callbacks = [];
-
-            foreach ($this->callback as $value) {
-                $callback = $value->compileAsArray();
-                if (! empty($callback)) {
-                    $callbacks[] = $callback;
-                }
-            }
-
-            if (! empty($callbacks)) {
-                $data['callback'] = $callbacks;
             }
         }
 

--- a/src/Endpoints/Media/Create/Availability.php
+++ b/src/Endpoints/Media/Create/Availability.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class Availability
+{
+    use CompilesProperties;
+
+    protected ?int $published = null;
+
+    protected int|string|null $expire_time = null;
+
+    protected int|string|null $available_time = null;
+
+    protected ?int $delete_source_after_transcode_hours = null;
+
+    protected ?int $delete_source_av_after_transcode_hours = null;
+
+    protected ?int $delete_transcode_after_upload_hours = null;
+
+    protected ?int $delete_all_after_upload_hours = null;
+
+    protected ?int $delete_all_after_expire_hours = null;
+
+    public function published(int $published): static
+    {
+        if (! in_array($published, [0, 1])) {
+            throw new \InvalidArgumentException('published must be 0 or 1');
+        }
+
+        $this->published = $published;
+
+        return $this;
+    }
+
+    /**
+     * Accepts a UNIX timestamp (integer) or a datetime string e.g. "2026-03-25 12:34:56".
+     */
+    public function expireTime(int|string $expire_time): static
+    {
+        $this->expire_time = $expire_time;
+
+        return $this;
+    }
+
+    /**
+     * Accepts a UNIX timestamp (integer) or a datetime string e.g. "2026-03-25 12:34:56".
+     */
+    public function availableTime(int|string $available_time): static
+    {
+        $this->available_time = $available_time;
+
+        return $this;
+    }
+
+    /**
+     * Use 0 to delete immediately, -1 to disable.
+     */
+    public function deleteSourceAfterTranscodeHours(int $delete_source_after_transcode_hours): static
+    {
+        if ($delete_source_after_transcode_hours < -1) {
+            throw new \InvalidArgumentException('delete_source_after_transcode_hours must be >= -1');
+        }
+
+        $this->delete_source_after_transcode_hours = $delete_source_after_transcode_hours;
+
+        return $this;
+    }
+
+    /**
+     * Use 0 to delete immediately, -1 to disable.
+     */
+    public function deleteSourceAvAfterTranscodeHours(int $delete_source_av_after_transcode_hours): static
+    {
+        if ($delete_source_av_after_transcode_hours < -1) {
+            throw new \InvalidArgumentException('delete_source_av_after_transcode_hours must be >= -1');
+        }
+
+        $this->delete_source_av_after_transcode_hours = $delete_source_av_after_transcode_hours;
+
+        return $this;
+    }
+
+    /**
+     * Use 0 to delete immediately, -1 to disable.
+     */
+    public function deleteTranscodeAfterUploadHours(int $delete_transcode_after_upload_hours): static
+    {
+        if ($delete_transcode_after_upload_hours < -1) {
+            throw new \InvalidArgumentException('delete_transcode_after_upload_hours must be >= -1');
+        }
+
+        $this->delete_transcode_after_upload_hours = $delete_transcode_after_upload_hours;
+
+        return $this;
+    }
+
+    /**
+     * Use 0 to delete immediately, -1 to disable.
+     */
+    public function deleteAllAfterUploadHours(int $delete_all_after_upload_hours): static
+    {
+        if ($delete_all_after_upload_hours < -1) {
+            throw new \InvalidArgumentException('delete_all_after_upload_hours must be >= -1');
+        }
+
+        $this->delete_all_after_upload_hours = $delete_all_after_upload_hours;
+
+        return $this;
+    }
+
+    /**
+     * Use 0 to delete immediately, -1 to disable.
+     */
+    public function deleteAllAfterExpireHours(int $delete_all_after_expire_hours): static
+    {
+        if ($delete_all_after_expire_hours < -1) {
+            throw new \InvalidArgumentException('delete_all_after_expire_hours must be >= -1');
+        }
+
+        $this->delete_all_after_expire_hours = $delete_all_after_expire_hours;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/Embed.php
+++ b/src/Endpoints/Media/Create/Embed.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\AspectRatioEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\PlayerProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\PlayerTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\ProtocolEnum;
+
+class Embed
+{
+    use CompilesProperties;
+
+    protected ?ProtocolEnum $protocol = null;
+
+    protected ?PlayerTypeEnum $player_type = null;
+
+    protected ?PlayerProtocolEnum $player_protocol = null;
+
+    protected ?AspectRatioEnum $aspect_ratio = null;
+
+    protected ?int $autoplay = null;
+
+    protected ?int $autosubs = null;
+
+    protected ?int $mute = null;
+
+    protected ?int $start_from = null;
+
+    protected ?int $start_random = null;
+
+    protected ?int $enable_public = null;
+
+    protected ?string $public_password = null;
+
+    protected ?int $enable_preview = null;
+
+    public function protocol(ProtocolEnum $protocol): static
+    {
+        $this->protocol = $protocol;
+
+        return $this;
+    }
+
+    public function playerType(PlayerTypeEnum $player_type): static
+    {
+        $this->player_type = $player_type;
+
+        return $this;
+    }
+
+    public function playerProtocol(PlayerProtocolEnum $player_protocol): static
+    {
+        $this->player_protocol = $player_protocol;
+
+        return $this;
+    }
+
+    public function aspectRatio(AspectRatioEnum $aspect_ratio): static
+    {
+        $this->aspect_ratio = $aspect_ratio;
+
+        return $this;
+    }
+
+    public function autoplay(int $autoplay): static
+    {
+        if (! in_array($autoplay, [0, 1])) {
+            throw new \InvalidArgumentException('autoplay must be 0 or 1');
+        }
+
+        $this->autoplay = $autoplay;
+
+        return $this;
+    }
+
+    public function autosubs(int $autosubs): static
+    {
+        if (! in_array($autosubs, [0, 1])) {
+            throw new \InvalidArgumentException('autosubs must be 0 or 1');
+        }
+
+        $this->autosubs = $autosubs;
+
+        return $this;
+    }
+
+    public function mute(int $mute): static
+    {
+        if (! in_array($mute, [0, 1])) {
+            throw new \InvalidArgumentException('mute must be 0 or 1');
+        }
+
+        $this->mute = $mute;
+
+        return $this;
+    }
+
+    public function startFrom(int $start_from): static
+    {
+        $this->start_from = $start_from;
+
+        return $this;
+    }
+
+    public function startRandom(int $start_random): static
+    {
+        if (! in_array($start_random, [0, 1])) {
+            throw new \InvalidArgumentException('start_random must be 0 or 1');
+        }
+
+        $this->start_random = $start_random;
+
+        return $this;
+    }
+
+    public function enablePublic(int $enable_public): static
+    {
+        if (! in_array($enable_public, [0, 1])) {
+            throw new \InvalidArgumentException('enable_public must be 0 or 1');
+        }
+
+        $this->enable_public = $enable_public;
+
+        return $this;
+    }
+
+    public function publicPassword(string $public_password): static
+    {
+        $this->public_password = $public_password;
+
+        return $this;
+    }
+
+    public function enablePreview(int $enable_preview): static
+    {
+        if (! in_array($enable_preview, [0, 1])) {
+            throw new \InvalidArgumentException('enable_preview must be 0 or 1');
+        }
+
+        $this->enable_preview = $enable_preview;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/Enums/AspectRatioEnum.php
+++ b/src/Endpoints/Media/Create/Enums/AspectRatioEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum AspectRatioEnum: string
+{
+    case RATIO_4_3 = '4:3';
+    case RATIO_5_4 = '5:4';
+    case RATIO_16_9 = '16:9';
+    case RATIO_21_9 = '21:9';
+    case RATIO_2_1 = '2:1';
+}

--- a/src/Endpoints/Media/Create/Enums/CustomTitleFontEnum.php
+++ b/src/Endpoints/Media/Create/Enums/CustomTitleFontEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum CustomTitleFontEnum: string
+{
+    case ARIAL = 'Arial, Helvetica, sans-serif';
+    case TIMES_NEW_ROMAN = "'Times New Roman', Times, serif";
+    case COURIER_NEW = "'Courier New', Courier, monospace";
+    case VERDANA = 'Verdana, Geneva, sans-serif';
+    case GEORGIA = "Georgia, 'Times New Roman', Times, serif";
+    case PALATINO = "'Palatino Linotype', 'Book Antiqua', Palatino, serif";
+    case COMIC_SANS = "'Comic Sans MS', Textile, cursive";
+    case TREBUCHET = "'Trebuchet MS', Helvetica, sans-serif";
+    case ARIAL_BLACK = "'Arial Black', Gadget, sans-serif";
+    case IMPACT = 'Impact, Charcoal, sans-serif';
+}

--- a/src/Endpoints/Media/Create/Enums/CustomTitleTextSizeEnum.php
+++ b/src/Endpoints/Media/Create/Enums/CustomTitleTextSizeEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum CustomTitleTextSizeEnum: string
+{
+    /** XS */
+    case SIZE_0_8 = '0.8';
+    /** S */
+    case SIZE_1 = '1';
+    /** M */
+    case SIZE_1_2 = '1.2';
+    /** L */
+    case SIZE_1_4 = '1.4';
+}

--- a/src/Endpoints/Media/Create/Enums/CustomTitleTypeEnum.php
+++ b/src/Endpoints/Media/Create/Enums/CustomTitleTypeEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum CustomTitleTypeEnum: string
+{
+    case TOP_LEFT = 'top-left';
+    case TOP_CENTER = 'top-center';
+    case TOP_RIGHT = 'top-right';
+    case MIDDLE_LEFT = 'middle-left';
+    case MIDDLE_CENTER = 'middle-center';
+    case MIDDLE_RIGHT = 'middle-right';
+    case BOTTOM_LEFT = 'bottom-left';
+    case BOTTOM_CENTER = 'bottom-center';
+    case BOTTOM_RIGHT = 'bottom-right';
+}

--- a/src/Endpoints/Media/Create/Enums/EncryptionMethodEnum.php
+++ b/src/Endpoints/Media/Create/Enums/EncryptionMethodEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum EncryptionMethodEnum: string
+{
+    case DRM = 'drm';
+    case AES = 'aes';
+    case DRMAES = 'drmaes';
+}

--- a/src/Endpoints/Media/Create/Enums/PlayerProtocolEnum.php
+++ b/src/Endpoints/Media/Create/Enums/PlayerProtocolEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum PlayerProtocolEnum: string
+{
+    case HLS = 'hls';
+    case DASH = 'dash';
+}

--- a/src/Endpoints/Media/Create/Enums/PlayerTypeEnum.php
+++ b/src/Endpoints/Media/Create/Enums/PlayerTypeEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum PlayerTypeEnum: string
+{
+    case REGULAR = 'regular';
+    case VR = 'vr';
+}

--- a/src/Endpoints/Media/Create/Enums/ProtocolEnum.php
+++ b/src/Endpoints/Media/Create/Enums/ProtocolEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum ProtocolEnum: string
+{
+    case HTTP = 'http';
+    case HTTPS = 'https';
+}

--- a/src/Endpoints/Media/Create/Enums/TokenDurationEnum.php
+++ b/src/Endpoints/Media/Create/Enums/TokenDurationEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums;
+
+enum TokenDurationEnum: string
+{
+    case ONE_HOUR = '1h';
+    case THREE_HOUR = '3h';
+    case SIX_HOUR = '6h';
+    case TWELVE_HOUR = '12h';
+    case DAY = '1d';
+    case WEEK = '1w';
+    case TWO_WEEKS = '2w';
+    case MONTH = '1m';
+}

--- a/src/Endpoints/Media/Create/Images.php
+++ b/src/Endpoints/Media/Create/Images.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Support\ValidateImage;
+
+class Images
+{
+    use CompilesProperties;
+
+    protected ?string $thumbnail = null;
+
+    protected ?string $placeholder = null;
+
+    public function thumbnail(?string $thumbnail): static
+    {
+        if (! ValidateImage::verify($thumbnail)) {
+            throw new \InvalidArgumentException('thumbnail must be a base64 encoded string');
+        }
+
+        $this->thumbnail = $thumbnail;
+
+        return $this;
+    }
+
+    public function placeholder(?string $placeholder): static
+    {
+        if (! ValidateImage::verify($placeholder)) {
+            throw new \InvalidArgumentException('placeholder must be a base64 encoded string');
+        }
+
+        $this->placeholder = $placeholder;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/Player.php
+++ b/src/Endpoints/Media/Create/Player.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class Player
+{
+    use CompilesProperties;
+
+    protected ?string $logo_redirect = null;
+
+    protected ?int $preload_content = null;
+
+    protected ?int $extended_buffer = null;
+
+    protected ?int $disable_pausing = null;
+
+    /**
+     * @var PlayerCustomTitle[]|null
+     */
+    protected ?array $custom_titles = null;
+
+    protected ?string $singular_live = null;
+
+    public function logoRedirect(string $logo_redirect): static
+    {
+        $this->logo_redirect = $logo_redirect;
+
+        return $this;
+    }
+
+    public function preloadContent(int $preload_content): static
+    {
+        if (! in_array($preload_content, [0, 1])) {
+            throw new \InvalidArgumentException('preload_content must be 0 or 1');
+        }
+
+        $this->preload_content = $preload_content;
+
+        return $this;
+    }
+
+    public function extendedBuffer(int $extended_buffer): static
+    {
+        if (! in_array($extended_buffer, [0, 1])) {
+            throw new \InvalidArgumentException('extended_buffer must be 0 or 1');
+        }
+
+        $this->extended_buffer = $extended_buffer;
+
+        return $this;
+    }
+
+    public function disablePausing(int $disable_pausing): static
+    {
+        if (! in_array($disable_pausing, [0, 1])) {
+            throw new \InvalidArgumentException('disable_pausing must be 0 or 1');
+        }
+
+        $this->disable_pausing = $disable_pausing;
+
+        return $this;
+    }
+
+    /**
+     * @param  PlayerCustomTitle[]  $custom_titles
+     */
+    public function customTitles(array $custom_titles): static
+    {
+        $this->custom_titles = $custom_titles;
+
+        return $this;
+    }
+
+    public function singularLive(string $singular_live): static
+    {
+        $this->singular_live = $singular_live;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/PlayerCustomTitle.php
+++ b/src/Endpoints/Media/Create/PlayerCustomTitle.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleFontEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleTextSizeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleTypeEnum;
+
+class PlayerCustomTitle
+{
+    use CompilesProperties;
+
+    protected ?string $text = null;
+
+    protected ?string $url_label = null;
+
+    protected ?CustomTitleTypeEnum $type = null;
+
+    protected ?int $start = null;
+
+    protected ?int $end = null;
+
+    protected ?CustomTitleFontEnum $font = null;
+
+    protected ?string $color = null;
+
+    protected ?string $background = null;
+
+    protected ?CustomTitleTextSizeEnum $text_size = null;
+
+    public function text(string $text): static
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function urlLabel(string $url_label): static
+    {
+        $this->url_label = $url_label;
+
+        return $this;
+    }
+
+    public function type(CustomTitleTypeEnum $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function start(int $start): static
+    {
+        $this->start = $start;
+
+        return $this;
+    }
+
+    public function end(int $end): static
+    {
+        $this->end = $end;
+
+        return $this;
+    }
+
+    public function font(CustomTitleFontEnum $font): static
+    {
+        $this->font = $font;
+
+        return $this;
+    }
+
+    public function color(string $color): static
+    {
+        if (! preg_match('/^(#[a-fA-F0-9]{6}|rgba\((\s*\d+\s*,){3}[\d\.]+\))$/', $color)) {
+            throw new \InvalidArgumentException('color must be in #ffffff or rgba(255,255,255,0.5) format');
+        }
+
+        $this->color = $color;
+
+        return $this;
+    }
+
+    public function background(string $background): static
+    {
+        if (! preg_match('/^(#[a-fA-F0-9]{6}|rgba\((\s*\d+\s*,){3}[\d\.]+\))$/', $background)) {
+            throw new \InvalidArgumentException('background must be in #ffffff or rgba(255,255,255,0.5) format');
+        }
+
+        $this->background = $background;
+
+        return $this;
+    }
+
+    public function textSize(CustomTitleTextSizeEnum $text_size): static
+    {
+        $this->text_size = $text_size;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/Presentation.php
+++ b/src/Endpoints/Media/Create/Presentation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class Presentation
+{
+    use CompilesProperties;
+
+    protected ?int $mode = null;
+
+    protected ?PresentationConfig $config = null;
+
+    public function mode(int $mode): static
+    {
+        if (! in_array($mode, [0, 1])) {
+            throw new \InvalidArgumentException('mode must be 0 or 1');
+        }
+
+        $this->mode = $mode;
+
+        return $this;
+    }
+
+    public function config(PresentationConfig $config): static
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/PresentationConfig.php
+++ b/src/Endpoints/Media/Create/PresentationConfig.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class PresentationConfig
+{
+    use CompilesProperties;
+
+    protected ?int $file_id = null;
+
+    protected ?string $url = null;
+
+    /**
+     * @var string[]|null
+     */
+    protected ?array $slides = null;
+
+    public function fileId(int $file_id): static
+    {
+        $this->file_id = $file_id;
+
+        return $this;
+    }
+
+    public function url(string $url): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @param  string[]  $slides
+     */
+    public function slides(array $slides): static
+    {
+        $this->slides = $slides;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/Security.php
+++ b/src/Endpoints/Media/Create/Security.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\TokenDurationEnum;
+
+class Security
+{
+    use CompilesProperties;
+
+    protected ?EncryptionMethodEnum $encryption_method = null;
+
+    protected ?TokenDurationEnum $token_duration = null;
+
+    protected ?int $use_token = null;
+
+    protected ?int $use_token_full = null;
+
+    public function encryptionMethod(EncryptionMethodEnum $encryption_method): static
+    {
+        $this->encryption_method = $encryption_method;
+
+        return $this;
+    }
+
+    public function tokenDuration(TokenDurationEnum $token_duration): static
+    {
+        $this->token_duration = $token_duration;
+
+        return $this;
+    }
+
+    public function useToken(int $use_token): static
+    {
+        if (! in_array($use_token, [0, 1])) {
+            throw new \InvalidArgumentException('use_token must be 0 or 1');
+        }
+
+        $this->use_token = $use_token;
+
+        return $this;
+    }
+
+    public function useTokenFull(int $use_token_full): static
+    {
+        if (! in_array($use_token_full, [0, 1])) {
+            throw new \InvalidArgumentException('use_token_full must be 0 or 1');
+        }
+
+        $this->use_token_full = $use_token_full;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Create/TranscodeInfo.php
+++ b/src/Endpoints/Media/Create/TranscodeInfo.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class TranscodeInfo
+{
+    use CompilesProperties;
+
+    protected ?string $dvb_lng_order = null;
+
+    protected ?int $preset_id = null;
+
+    public function dvbLngOrder(string $dvb_lng_order): static
+    {
+        $this->dvb_lng_order = $dvb_lng_order;
+
+        return $this;
+    }
+
+    public function presetId(int $preset_id): static
+    {
+        if ($preset_id < 0) {
+            throw new \InvalidArgumentException('preset_id must be >= 0');
+        }
+
+        $this->preset_id = $preset_id;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/MediaList.php
+++ b/src/Endpoints/Media/MediaList.php
@@ -7,7 +7,11 @@ namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 use Carbon\CarbonInterface;
 use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
 use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\FileExtension;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\MediaInfo;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\OrderByEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\PeriodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\Popular;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\PublisherStatusEnum;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\StatusEnum;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
@@ -25,6 +29,10 @@ class MediaList extends AbstractEndpoint implements EndpointContract
      */
     protected ?array $ids = null;
 
+    protected ?int $id_from = null;
+
+    protected ?int $id_to = null;
+
     /**
      * @var array<string>|null
      */
@@ -39,15 +47,34 @@ class MediaList extends AbstractEndpoint implements EndpointContract
 
     protected string|int|CarbonInterface|null $created_to = null;
 
+    protected ?PeriodEnum $created_period = null;
+
     protected string|int|CarbonInterface|null $updated_from = null;
 
     protected string|int|CarbonInterface|null $updated_to = null;
+
+    protected ?PeriodEnum $updated_period = null;
+
+    protected string|int|CarbonInterface|null $published_from = null;
+
+    protected string|int|CarbonInterface|null $published_to = null;
+
+    protected ?PeriodEnum $published_period = null;
 
     protected ?bool $published = null;
 
     protected ?PublisherStatusEnum $publisher_status = null;
 
     protected ?bool $only_available = null;
+
+    /**
+     * Wildcard. Can also be an array of string wildcards.
+     *
+     * @var array<string>|string|null
+     */
+    protected array|string|null $name = null;
+
+    protected ?string $pg_rating = null;
 
     protected ?string $search = null;
 
@@ -57,9 +84,41 @@ class MediaList extends AbstractEndpoint implements EndpointContract
     protected ?array $status = null;
 
     /**
+     * @var array<StatusEnum>|null
+     */
+    protected ?array $status_exclude = null;
+
+    /**
+     * Available values: warning, error, transcoded, multi_bitrate, published, expired, scheduled.
+     *
+     * @var array<string>|null
+     */
+    protected ?array $tech_status = null;
+
+    /**
+     * Available values: warning, error, transcoded, multi_bitrate, published, expired, scheduled.
+     *
+     * @var array<string>|null
+     */
+    protected ?array $tech_status_exclude = null;
+
+    /**
      * @var array<string>|null
      */
     protected ?array $tags = null;
+
+    /**
+     * Filter by errors/warnings. Requires search_index_ready.
+     *
+     * @var array<string>|null
+     */
+    protected ?array $errors_warnings = null;
+
+    protected ?FileExtension $file_extension = null;
+
+    protected ?MediaInfo $media_info = null;
+
+    protected ?Popular $popular = null;
 
     protected ?int $limit = null;
 
@@ -69,16 +128,27 @@ class MediaList extends AbstractEndpoint implements EndpointContract
 
     protected ?OrderDirectionEnum $order_dir = null;
 
+    /**
+     * @var array<int>|null
+     */
+    protected ?array $order_specific = null;
+
     protected ?bool $images_fallback = null;
+
+    /**
+     * @var array<mixed>|null
+     */
+    protected ?array $metadata = null;
 
     /**
      * @var array<string>|null
      */
     protected ?array $return = null;
 
+    protected ?string $timezone = null;
+
     /**
      * @param  array<int>|null  $ids
-     * @return $this
      */
     public function ids(?array $ids): static
     {
@@ -87,9 +157,22 @@ class MediaList extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    public function idFrom(?int $id_from): static
+    {
+        $this->id_from = $id_from;
+
+        return $this;
+    }
+
+    public function idTo(?int $id_to): static
+    {
+        $this->id_to = $id_to;
+
+        return $this;
+    }
+
     /**
      * @param  array<string>|null  $asset_ids
-     * @return $this
      */
     public function assetIds(?array $asset_ids): static
     {
@@ -100,7 +183,6 @@ class MediaList extends AbstractEndpoint implements EndpointContract
 
     /**
      * @param  array<int>|null  $ids
-     * @return $this
      */
     public function categoryIds(?array $ids): static
     {
@@ -123,6 +205,13 @@ class MediaList extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    public function createdPeriod(?PeriodEnum $created_period): static
+    {
+        $this->created_period = $created_period;
+
+        return $this;
+    }
+
     public function updatedFrom(string|int|CarbonInterface|null $updated_from): static
     {
         $this->updated_from = $updated_from;
@@ -133,6 +222,34 @@ class MediaList extends AbstractEndpoint implements EndpointContract
     public function updatedTo(string|int|CarbonInterface|null $updated_to): static
     {
         $this->updated_to = $updated_to;
+
+        return $this;
+    }
+
+    public function updatedPeriod(?PeriodEnum $updated_period): static
+    {
+        $this->updated_period = $updated_period;
+
+        return $this;
+    }
+
+    public function publishedFrom(string|int|CarbonInterface|null $published_from): static
+    {
+        $this->published_from = $published_from;
+
+        return $this;
+    }
+
+    public function publishedTo(string|int|CarbonInterface|null $published_to): static
+    {
+        $this->published_to = $published_to;
+
+        return $this;
+    }
+
+    public function publishedPeriod(?PeriodEnum $published_period): static
+    {
+        $this->published_period = $published_period;
 
         return $this;
     }
@@ -158,6 +275,23 @@ class MediaList extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * @param  array<string>|string|null  $name
+     */
+    public function name(array|string|null $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function pgRating(?string $pg_rating): static
+    {
+        $this->pg_rating = $pg_rating;
+
+        return $this;
+    }
+
     public function search(?string $phrase): static
     {
         $this->search = $phrase;
@@ -167,7 +301,6 @@ class MediaList extends AbstractEndpoint implements EndpointContract
 
     /**
      * @param  StatusEnum|array<StatusEnum>|null  $status
-     * @return $this
      */
     public function status(StatusEnum|array|null $status): static
     {
@@ -177,12 +310,76 @@ class MediaList extends AbstractEndpoint implements EndpointContract
     }
 
     /**
+     * @param  StatusEnum|array<StatusEnum>|null  $status_exclude
+     */
+    public function statusExclude(StatusEnum|array|null $status_exclude): static
+    {
+        $this->status_exclude = $status_exclude === null ? null : (! is_array($status_exclude) ? [$status_exclude] : $status_exclude);
+
+        return $this;
+    }
+
+    /**
+     * Available values: warning, error, transcoded, multi_bitrate, published, expired, scheduled.
+     *
+     * @param  array<string>|null  $tech_status
+     */
+    public function techStatus(?array $tech_status): static
+    {
+        $this->tech_status = $tech_status;
+
+        return $this;
+    }
+
+    /**
+     * Available values: warning, error, transcoded, multi_bitrate, published, expired, scheduled.
+     *
+     * @param  array<string>|null  $tech_status_exclude
+     */
+    public function techStatusExclude(?array $tech_status_exclude): static
+    {
+        $this->tech_status_exclude = $tech_status_exclude;
+
+        return $this;
+    }
+
+    /**
      * @param  array<string>|null  $tags
-     * @return $this
      */
     public function tags(?array $tags): static
     {
         $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string>|null  $errors_warnings
+     */
+    public function errorsWarnings(?array $errors_warnings): static
+    {
+        $this->errors_warnings = $errors_warnings;
+
+        return $this;
+    }
+
+    public function fileExtension(?FileExtension $file_extension): static
+    {
+        $this->file_extension = $file_extension;
+
+        return $this;
+    }
+
+    public function mediaInfo(?MediaInfo $media_info): static
+    {
+        $this->media_info = $media_info;
+
+        return $this;
+    }
+
+    public function popular(?Popular $popular): static
+    {
+        $this->popular = $popular;
 
         return $this;
     }
@@ -219,6 +416,16 @@ class MediaList extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
+    /**
+     * @param  array<int>|null  $order_specific
+     */
+    public function orderSpecific(?array $order_specific): static
+    {
+        $this->order_specific = $order_specific;
+
+        return $this;
+    }
+
     public function imagesFallback(?bool $fallback): static
     {
         $this->images_fallback = $fallback;
@@ -227,12 +434,28 @@ class MediaList extends AbstractEndpoint implements EndpointContract
     }
 
     /**
+     * @param  array<mixed>|null  $metadata
+     */
+    public function metadata(?array $metadata): static
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+    /**
      * @param  array<string>|null  $return
-     * @return $this
      */
     public function return(?array $return): static
     {
         $this->return = $return;
+
+        return $this;
+    }
+
+    public function timezone(?string $timezone): static
+    {
+        $this->timezone = $timezone;
 
         return $this;
     }
@@ -264,6 +487,14 @@ class MediaList extends AbstractEndpoint implements EndpointContract
             $query['id'] = $this->ids;
         }
 
+        if ($this->id_from !== null) {
+            $query['id_from'] = $this->id_from;
+        }
+
+        if ($this->id_to !== null) {
+            $query['id_to'] = $this->id_to;
+        }
+
         if ($this->asset_ids !== null) {
             $query['asset_id'] = $this->asset_ids;
         }
@@ -280,12 +511,32 @@ class MediaList extends AbstractEndpoint implements EndpointContract
             $query['created_to'] = $this->created_to instanceof CarbonInterface ? $this->created_to->toDateTimeString() : $this->created_to;
         }
 
+        if ($this->created_period !== null) {
+            $query['created_period'] = $this->created_period->value;
+        }
+
         if ($this->updated_from !== null) {
             $query['updated_from'] = $this->updated_from instanceof CarbonInterface ? $this->updated_from->toDateTimeString() : $this->updated_from;
         }
 
         if ($this->updated_to !== null) {
             $query['updated_to'] = $this->updated_to instanceof CarbonInterface ? $this->updated_to->toDateTimeString() : $this->updated_to;
+        }
+
+        if ($this->updated_period !== null) {
+            $query['updated_period'] = $this->updated_period->value;
+        }
+
+        if ($this->published_from !== null) {
+            $query['published_from'] = $this->published_from instanceof CarbonInterface ? $this->published_from->toDateTimeString() : $this->published_from;
+        }
+
+        if ($this->published_to !== null) {
+            $query['published_to'] = $this->published_to instanceof CarbonInterface ? $this->published_to->toDateTimeString() : $this->published_to;
+        }
+
+        if ($this->published_period !== null) {
+            $query['published_period'] = $this->published_period->value;
         }
 
         if ($this->published !== null) {
@@ -300,6 +551,14 @@ class MediaList extends AbstractEndpoint implements EndpointContract
             $query['only_available'] = $this->only_available ? 1 : 0;
         }
 
+        if ($this->name !== null) {
+            $query['name'] = $this->name;
+        }
+
+        if ($this->pg_rating !== null) {
+            $query['pg_rating'] = $this->pg_rating;
+        }
+
         if ($this->search !== null) {
             $query['search'] = $this->search;
         }
@@ -308,8 +567,48 @@ class MediaList extends AbstractEndpoint implements EndpointContract
             $query['status'] = array_map(fn (StatusEnum $status) => $status->value, $this->status);
         }
 
+        if ($this->status_exclude !== null) {
+            $query['status_exclude'] = array_map(fn (StatusEnum $status) => $status->value, $this->status_exclude);
+        }
+
+        if ($this->tech_status !== null) {
+            $query['tech_status'] = $this->tech_status;
+        }
+
+        if ($this->tech_status_exclude !== null) {
+            $query['tech_status_exclude'] = $this->tech_status_exclude;
+        }
+
         if ($this->tags !== null) {
             $query['tags'] = $this->tags;
+        }
+
+        if ($this->errors_warnings !== null) {
+            $query['errors_warnings'] = $this->errors_warnings;
+        }
+
+        if ($this->file_extension !== null) {
+            $file_extension = $this->file_extension->compileAsArray();
+
+            if (! empty($file_extension)) {
+                $query['file_extension'] = $file_extension;
+            }
+        }
+
+        if ($this->media_info !== null) {
+            $media_info = $this->media_info->compileAsArray();
+
+            if (! empty($media_info)) {
+                $query['media_info'] = $media_info;
+            }
+        }
+
+        if ($this->popular !== null) {
+            $popular = $this->popular->compileAsArray();
+
+            if (! empty($popular)) {
+                $query['popular'] = $popular;
+            }
         }
 
         if ($this->limit !== null) {
@@ -328,12 +627,24 @@ class MediaList extends AbstractEndpoint implements EndpointContract
             $query['order_dir'] = $this->order_dir->value;
         }
 
+        if ($this->order_specific !== null) {
+            $query['order_specific'] = $this->order_specific;
+        }
+
         if ($this->images_fallback !== null) {
             $query['images_fallback'] = $this->images_fallback ? 1 : 0;
         }
 
+        if ($this->metadata !== null) {
+            $query['metadata'] = $this->metadata;
+        }
+
         if ($this->return !== null) {
             $query['return'] = $this->return;
+        }
+
+        if ($this->timezone !== null) {
+            $query['timezone'] = $this->timezone;
         }
 
         $http->withQuery($query);

--- a/src/Endpoints/Media/MediaList/FileExtension.php
+++ b/src/Endpoints/Media/MediaList/FileExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class FileExtension
+{
+    use CompilesProperties;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $source = null;
+
+    /**
+     * @param  array<string>  $source
+     */
+    public function source(array $source): static
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/MediaList/MediaInfo.php
+++ b/src/Endpoints/Media/MediaList/MediaInfo.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class MediaInfo
+{
+    use CompilesProperties;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $resolution = null;
+
+    /**
+     * hh:mm:ss values
+     *
+     * @var array<string>|null
+     */
+    protected ?array $length = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $gop_type = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $gop_size = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $frame_rate = null;
+
+    /**
+     * e.g. sdr, hdr
+     *
+     * @var array<string>|null
+     */
+    protected ?array $content_type = null;
+
+    /**
+     * e.g. mono, stereo, 5.1, 7.1
+     *
+     * @var array<string>|null
+     */
+    protected ?array $audio_type = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $audio_tracks_count = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $codec = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $language = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $subtitle_language = null;
+
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $audio_language = null;
+
+    /** @param array<string> $resolution */
+    public function resolution(array $resolution): static
+    {
+        $this->resolution = $resolution;
+
+        return $this;
+    }
+
+    /** @param array<string> $length */
+    public function length(array $length): static
+    {
+        $this->length = $length;
+
+        return $this;
+    }
+
+    /** @param array<string> $gop_type */
+    public function gopType(array $gop_type): static
+    {
+        $this->gop_type = $gop_type;
+
+        return $this;
+    }
+
+    /** @param array<string> $gop_size */
+    public function gopSize(array $gop_size): static
+    {
+        $this->gop_size = $gop_size;
+
+        return $this;
+    }
+
+    /** @param array<string> $frame_rate */
+    public function frameRate(array $frame_rate): static
+    {
+        $this->frame_rate = $frame_rate;
+
+        return $this;
+    }
+
+    /** @param array<string> $content_type */
+    public function contentType(array $content_type): static
+    {
+        $this->content_type = $content_type;
+
+        return $this;
+    }
+
+    /** @param array<string> $audio_type */
+    public function audioType(array $audio_type): static
+    {
+        $this->audio_type = $audio_type;
+
+        return $this;
+    }
+
+    /** @param array<string> $audio_tracks_count */
+    public function audioTracksCount(array $audio_tracks_count): static
+    {
+        $this->audio_tracks_count = $audio_tracks_count;
+
+        return $this;
+    }
+
+    /** @param array<string> $codec */
+    public function codec(array $codec): static
+    {
+        $this->codec = $codec;
+
+        return $this;
+    }
+
+    /** @param array<string> $language */
+    public function language(array $language): static
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    /** @param array<string> $subtitle_language */
+    public function subtitleLanguage(array $subtitle_language): static
+    {
+        $this->subtitle_language = $subtitle_language;
+
+        return $this;
+    }
+
+    /** @param array<string> $audio_language */
+    public function audioLanguage(array $audio_language): static
+    {
+        $this->audio_language = $audio_language;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/MediaList/OrderByEnum.php
+++ b/src/Endpoints/Media/MediaList/OrderByEnum.php
@@ -14,7 +14,14 @@ enum OrderByEnum: string
     case STATUS = 'status';
     case CREATED_AT = 'created_at';
     case UPDATED_AT = 'updated_at';
+    case DURATION = 'duration';
+    case STATUS_SIMPLE = 'status_simple';
+    case STATUS_ADVANCED = 'status_advanced';
+    case APPROVED_AT = 'approved_at';
+    case TRANSCODED_AT = 'transcoded_at';
+    case PUBLISHED_AT = 'published_at';
     case AVAILABILITY_EXPIRE_TIME = 'availability.expire_time';
     case AVAILABILITY_AVAILABLE_TIME = 'availability.available_time';
     case CATEGORY_NAME = 'category.name';
+    case TRANSCODING_ORDER = 'transcoding_order';
 }

--- a/src/Endpoints/Media/MediaList/PeriodEnum.php
+++ b/src/Endpoints/Media/MediaList/PeriodEnum.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+
+enum PeriodEnum: string
+{
+    case THIS_HOUR = 'this hour';
+    case LAST_HOUR = 'last hour';
+    case TODAY = 'today';
+    case YESTERDAY = 'yesterday';
+    case LAST_7_DAYS = 'last 7 days';
+    case LAST_15_DAYS = 'last 15 days';
+    case LAST_30_DAYS = 'last 30 days';
+    case LAST_60_DAYS = 'last 60 days';
+    case THIS_WEEK = 'this week';
+    case LAST_WEEK = 'last week';
+    case THIS_MONTH = 'this month';
+    case LAST_MONTH = 'last month';
+    case LAST_2_MONTHS = 'last 2 months';
+    case LAST_3_MONTHS = 'last 3 months';
+    case LAST_6_MONTHS = 'last 6 months';
+    case THIS_YEAR = 'this year';
+    case LAST_YEAR = 'last year';
+}

--- a/src/Endpoints/Media/MediaList/Popular.php
+++ b/src/Endpoints/Media/MediaList/Popular.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+
+use Carbon\CarbonInterface;
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
+
+class Popular
+{
+    use CompilesProperties;
+
+    protected ?PopularSourceEnum $source = null;
+
+    protected string|int|CarbonInterface|null $date_from = null;
+
+    protected string|int|CarbonInterface|null $date_to = null;
+
+    protected ?PeriodEnum $date_period = null;
+
+    protected ?OrderDirectionEnum $order_dir = null;
+
+    public function source(PopularSourceEnum $source): static
+    {
+        $this->source = $source;
+
+        return $this;
+    }
+
+    public function dateFrom(string|int|CarbonInterface $date_from): static
+    {
+        $this->date_from = $date_from;
+
+        return $this;
+    }
+
+    public function dateTo(string|int|CarbonInterface $date_to): static
+    {
+        $this->date_to = $date_to;
+
+        return $this;
+    }
+
+    public function datePeriod(PeriodEnum $date_period): static
+    {
+        $this->date_period = $date_period;
+
+        return $this;
+    }
+
+    public function orderDir(OrderDirectionEnum $order_dir): static
+    {
+        $this->order_dir = $order_dir;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/MediaList/PopularSourceEnum.php
+++ b/src/Endpoints/Media/MediaList/PopularSourceEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+
+enum PopularSourceEnum: string
+{
+    case YOUBORA = 'youbora';
+    case INTERNAL = 'internal';
+}

--- a/src/Endpoints/Media/MediaList/StatusEnum.php
+++ b/src/Endpoints/Media/MediaList/StatusEnum.php
@@ -7,14 +7,21 @@ namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
 enum StatusEnum: string
 {
     case ANY = 'any';
+    case DRAFT = 'draft';
+    case PROCESSING = 'processing';
+    case READY = 'ready';
+    case ARCHIVED = 'archived';
     case ERROR = 'error';
-    case INGESTED = 'ingested';
     case NEW = 'new';
+    case INGESTED = 'ingested';
+    case INGESTING = 'ingesting';
+    case VALIDATE = 'validate';
+    case VALIDATING = 'validating';
+    case VALIDATED = 'validated';
+    case TRANSCODING = 'transcoding';
     case PLAYABLE = 'playable';
     case PRIORITY = 'priority';
     case PROCESSED = 'processed';
-    case PROCESSING = 'processing';
     case UPLOADED = 'uploaded';
-    case VALIDATED = 'validated';
     case APPROVED = 'approved';
 }

--- a/src/Endpoints/Media/Publish.php
+++ b/src/Endpoints/Media/Publish.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+
+/**
+ * @link https://api.backscreen.com/api/v5/docs#/operations/Media/Publish
+ */
+class Publish extends AbstractEndpoint implements EndpointContract
+{
+    /**
+     * @param  int|array<int>  $id
+     */
+    public function __construct(
+        protected int|array $id,
+        protected int $published,
+    ) {
+        if (! in_array($published, [0, 1])) {
+            throw new \InvalidArgumentException('published must be 0 or 1');
+        }
+    }
+
+    /**
+     * Define which authentication methods are allowed to call this endpoint.
+     *
+     * @return AuthMethodEnum[]
+     */
+    public function allowedAuthMethods(): array
+    {
+        return [AuthMethodEnum::BEARER];
+    }
+
+    /**
+     * HTTP Method to use for request.
+     */
+    public function useHttpMethod(): HttpMethodEnum
+    {
+        return HttpMethodEnum::PUT;
+    }
+
+    /**
+     * Endpoint url.
+     */
+    public function endpointUrl(): string
+    {
+        return '/Media/Publish';
+    }
+
+    /**
+     * Prepares HTTP request for this endpoint.
+     */
+    public function prepareHttpRequest(PendingRequest $http): void
+    {
+        $http->withData([
+            'id' => $this->id,
+            'published' => $this->published,
+        ]);
+    }
+}

--- a/src/Endpoints/Media/RemoveWarning.php
+++ b/src/Endpoints/Media/RemoveWarning.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+
+/**
+ * @link https://api.backscreen.com/api/v5/docs#/operations/Media/Removewarning
+ */
+class RemoveWarning extends AbstractEndpoint implements EndpointContract
+{
+    public function __construct(
+        protected int $id,
+        protected string $warning,
+    ) {}
+
+    /**
+     * Define which authentication methods are allowed to call this endpoint.
+     *
+     * @return AuthMethodEnum[]
+     */
+    public function allowedAuthMethods(): array
+    {
+        return [AuthMethodEnum::BASIC, AuthMethodEnum::BEARER];
+    }
+
+    /**
+     * HTTP Method to use for request.
+     */
+    public function useHttpMethod(): HttpMethodEnum
+    {
+        return HttpMethodEnum::PUT;
+    }
+
+    /**
+     * Endpoint url.
+     */
+    public function endpointUrl(): string
+    {
+        return '/Media/Removewarning';
+    }
+
+    /**
+     * Prepares HTTP request for this endpoint.
+     */
+    public function prepareHttpRequest(PendingRequest $http): void
+    {
+        $http->withData([
+            'id' => $this->id,
+            'warning' => $this->warning,
+        ]);
+    }
+}

--- a/src/Endpoints/Media/Update.php
+++ b/src/Endpoints/Media/Update.php
@@ -6,9 +6,19 @@ namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
 
 use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
 use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Player;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Presentation;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Tags;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\UpdateManifest;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as LegacyImages;
 use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
 use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
 
@@ -17,16 +27,62 @@ use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
  */
 class Update extends AbstractEndpoint implements EndpointContract
 {
+    protected ?int $cat_id = null;
+
     protected ?string $name = null;
 
     protected ?string $description = null;
 
+    protected ?string $pg_rating = null;
+
+    protected ?int $auto_transcode = null;
+
+    protected ?int $embed_player_id = null;
+
+    protected ?int $embed_ad_id = null;
+
+    protected ?int $embed_protection_id = null;
+
+    protected ?TranscodeInfo $transcode_info = null;
+
     protected ?Images $images = null;
+
+    protected ?Embed $embed = null;
+
+    protected ?Presentation $presentation = null;
+
+    protected ?Player $player = null;
+
+    /** @var Files[]|null */
+    protected ?array $files = null;
+
+    protected ?Security $security = null;
+
+    protected ?Availability $availability = null;
+
+    /**
+     * @var array<mixed>|null
+     */
+    protected ?array $metadata = null;
+
+    protected ?string $timezone = null;
+
+    protected ?Tags $tags = null;
+
+    /** @var UpdateManifest[]|null */
+    protected ?array $update_manifests = null;
 
     /** @var Callback[]|null */
     protected ?array $callback = null;
 
     public function __construct(protected ByContract $by) {}
+
+    public function catId(?int $cat_id): static
+    {
+        $this->cat_id = $cat_id;
+
+        return $this;
+    }
 
     public function name(?string $name): static
     {
@@ -42,14 +98,174 @@ class Update extends AbstractEndpoint implements EndpointContract
         return $this;
     }
 
-    public function images(?Images $images): static
+    public function pgRating(?string $pg_rating): static
     {
+        $this->pg_rating = $pg_rating;
+
+        return $this;
+    }
+
+    /**
+     * Allowed values: 0 or 1.
+     */
+    public function autoTranscode(?int $auto_transcode): static
+    {
+        $this->auto_transcode = $auto_transcode;
+
+        return $this;
+    }
+
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
+    public function embedPlayerId(?int $embed_player_id): static
+    {
+        if ($embed_player_id !== null && $embed_player_id < -1) {
+            throw new \InvalidArgumentException('embed_player_id must be >= -1');
+        }
+
+        $this->embed_player_id = $embed_player_id;
+
+        return $this;
+    }
+
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
+    public function embedAdId(?int $embed_ad_id): static
+    {
+        if ($embed_ad_id !== null && $embed_ad_id < -1) {
+            throw new \InvalidArgumentException('embed_ad_id must be >= -1');
+        }
+
+        $this->embed_ad_id = $embed_ad_id;
+
+        return $this;
+    }
+
+    /**
+     * -1 = inherit, 0 = none, >0 = Specific ID
+     */
+    public function embedProtectionId(?int $embed_protection_id): static
+    {
+        if ($embed_protection_id !== null && $embed_protection_id < -1) {
+            throw new \InvalidArgumentException('embed_protection_id must be >= -1');
+        }
+
+        $this->embed_protection_id = $embed_protection_id;
+
+        return $this;
+    }
+
+    public function transcodeInfo(?TranscodeInfo $transcode_info): static
+    {
+        $this->transcode_info = $transcode_info;
+
+        return $this;
+    }
+
+    public function images(Images|LegacyImages|null $images): static
+    {
+        if ($images instanceof LegacyImages) {
+            /** @var array{thumbnail?: string, placeholder?: string} $compiled */
+            $compiled = $images->compileAsArray();
+
+            $images = new Images;
+            if (isset($compiled['thumbnail'])) {
+                $images->thumbnail($compiled['thumbnail']);
+            }
+            if (isset($compiled['placeholder'])) {
+                $images->placeholder($compiled['placeholder']);
+            }
+        }
+
         $this->images = $images;
 
         return $this;
     }
 
-    /** @param Callback[]|null $callback */
+    public function embed(?Embed $embed): static
+    {
+        $this->embed = $embed;
+
+        return $this;
+    }
+
+    public function presentation(?Presentation $presentation): static
+    {
+        $this->presentation = $presentation;
+
+        return $this;
+    }
+
+    public function player(?Player $player): static
+    {
+        $this->player = $player;
+
+        return $this;
+    }
+
+    /**
+     * @param  Files[]|null  $files
+     */
+    public function files(?array $files): static
+    {
+        $this->files = $files;
+
+        return $this;
+    }
+
+    public function security(?Security $security): static
+    {
+        $this->security = $security;
+
+        return $this;
+    }
+
+    public function availability(?Availability $availability): static
+    {
+        $this->availability = $availability;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<mixed>|null  $metadata
+     */
+    public function metadata(?array $metadata): static
+    {
+        $this->metadata = $metadata;
+
+        return $this;
+    }
+
+    public function timezone(?string $timezone): static
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function tags(?Tags $tags): static
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @param  UpdateManifest[]|null  $update_manifests
+     */
+    public function updateManifests(?array $update_manifests): static
+    {
+        $this->update_manifests = $update_manifests;
+
+        return $this;
+    }
+
+    /**
+     * @param  Callback[]|null  $callback
+     */
     public function callback(?array $callback): static
     {
         $this->callback = $callback;
@@ -82,6 +298,10 @@ class Update extends AbstractEndpoint implements EndpointContract
             $this->by->getFieldName() => $this->by->getValue(),
         ];
 
+        if ($this->cat_id !== null) {
+            $data['cat_id'] = $this->cat_id;
+        }
+
         if ($this->name !== null) {
             $data['name'] = $this->name;
         }
@@ -90,11 +310,125 @@ class Update extends AbstractEndpoint implements EndpointContract
             $data['description'] = $this->description;
         }
 
+        if ($this->pg_rating !== null) {
+            $data['pg_rating'] = $this->pg_rating;
+        }
+
+        if ($this->auto_transcode !== null) {
+            $data['auto_transcode'] = $this->auto_transcode;
+        }
+
+        if ($this->embed_player_id !== null) {
+            $data['embed_player_id'] = $this->embed_player_id;
+        }
+
+        if ($this->embed_ad_id !== null) {
+            $data['embed_ad_id'] = $this->embed_ad_id;
+        }
+
+        if ($this->embed_protection_id !== null) {
+            $data['embed_protection_id'] = $this->embed_protection_id;
+        }
+
+        if ($this->transcode_info !== null) {
+            $transcode_info = $this->transcode_info->compileAsArray();
+
+            if (! empty($transcode_info)) {
+                $data['transcode_info'] = $transcode_info;
+            }
+        }
+
         if ($this->images !== null) {
             $images = $this->images->compileAsArray();
 
             if (! empty($images)) {
                 $data['images'] = $images;
+            }
+        }
+
+        if ($this->embed !== null) {
+            $embed = $this->embed->compileAsArray();
+
+            if (! empty($embed)) {
+                $data['embed'] = $embed;
+            }
+        }
+
+        if ($this->presentation !== null) {
+            $presentation = $this->presentation->compileAsArray();
+
+            if (! empty($presentation)) {
+                $data['presentation'] = $presentation;
+            }
+        }
+
+        if ($this->player !== null) {
+            $player = $this->player->compileAsArray();
+
+            if (! empty($player)) {
+                $data['player'] = $player;
+            }
+        }
+
+        if ($this->files !== null) {
+            $files = [];
+
+            foreach ($this->files as $value) {
+                $file = $value->compileAsArray();
+                if (! empty($file)) {
+                    $files[] = $file;
+                }
+            }
+
+            if (! empty($files)) {
+                $data['files'] = $files;
+            }
+        }
+
+        if ($this->security !== null) {
+            $security = $this->security->compileAsArray();
+
+            if (! empty($security)) {
+                $data['security'] = $security;
+            }
+        }
+
+        if ($this->availability !== null) {
+            $availability = $this->availability->compileAsArray();
+
+            if (! empty($availability)) {
+                $data['availability'] = $availability;
+            }
+        }
+
+        if ($this->metadata !== null) {
+            $data['metadata'] = $this->metadata;
+        }
+
+        if ($this->timezone !== null) {
+            $data['timezone'] = $this->timezone;
+        }
+
+        if ($this->tags !== null) {
+            $tags = $this->tags->compileAsArray();
+
+            if (! empty($tags)) {
+                $data['tags'] = $tags;
+            }
+        }
+
+        if ($this->update_manifests !== null) {
+            $manifests = [];
+
+            foreach ($this->update_manifests as $value) {
+                $manifest = $value->compileAsArray();
+                if (! empty($manifest)) {
+                    $manifests[] = $manifest;
+                }
+            }
+
+            if (! empty($manifests)) {
+                $data['update_manifests'] = $manifests;
             }
         }
 

--- a/src/Endpoints/Media/Update/Embed.php
+++ b/src/Endpoints/Media/Update/Embed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Embed as BaseEmbed;
+
+class Embed extends BaseEmbed
+{
+    //
+}

--- a/src/Endpoints/Media/Update/Enums/MaterialChangeTypeEnum.php
+++ b/src/Endpoints/Media/Update/Enums/MaterialChangeTypeEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Enums;
+
+enum MaterialChangeTypeEnum: string
+{
+    case THUMBNAIL = 'thumbnail';
+    case PLACEHOLDER = 'placeholder';
+}

--- a/src/Endpoints/Media/Update/Images.php
+++ b/src/Endpoints/Media/Update/Images.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as BaseImages;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images as BaseImages;
 
 class Images extends BaseImages
 {

--- a/src/Endpoints/Media/Update/MaterialChange.php
+++ b/src/Endpoints/Media/Update/MaterialChange.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Enums\MaterialChangeTypeEnum;
+
+class MaterialChange
+{
+    use CompilesProperties;
+
+    protected ?MaterialChangeTypeEnum $type = null;
+
+    protected ?int $timestamp = null;
+
+    public function type(MaterialChangeTypeEnum $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function timestamp(int $timestamp): static
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Update/Tags.php
+++ b/src/Endpoints/Media/Update/Tags.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags as BaseTags;
+
+class Tags extends BaseTags
+{
+    /**
+     * @var array<string>|null
+     */
+    protected ?array $remove = null;
+
+    /**
+     * @param  array<string>  $remove
+     */
+    public function remove(array $remove): static
+    {
+        $this->remove = $remove;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/Update/UpdateManifest.php
+++ b/src/Endpoints/Media/Update/UpdateManifest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class UpdateManifest
+{
+    use CompilesProperties;
+
+    protected ?int $id = null;
+
+    protected ?int $start_at = null;
+
+    protected ?int $end_at = null;
+
+    protected ?MaterialChange $material_change = null;
+
+    public function id(int $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function startAt(int $start_at): static
+    {
+        $this->start_at = $start_at;
+
+        return $this;
+    }
+
+    public function endAt(int $end_at): static
+    {
+        $this->end_at = $end_at;
+
+        return $this;
+    }
+
+    public function materialChange(MaterialChange $material_change): static
+    {
+        $this->material_change = $material_change;
+
+        return $this;
+    }
+}

--- a/src/Endpoints/Media/UploadToExternal.php
+++ b/src/Endpoints/Media/UploadToExternal.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\CustomFile;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\PackageFile;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+
+/**
+ * @link https://api.backscreen.com/api/v5/docs#/operations/Media/Uploadtoexternal
+ */
+class UploadToExternal extends AbstractEndpoint implements EndpointContract
+{
+    /**
+     * @var PackageFile[]|null
+     */
+    protected ?array $package_files = null;
+
+    /**
+     * @var CustomFile[]|null
+     */
+    protected ?array $custom_files = null;
+
+    protected ?string $path = null;
+
+    protected ?int $cat_dir = null;
+
+    protected ?int $asset_dir = null;
+
+    /**
+     * @param  int|array<int>  $id
+     */
+    public function __construct(
+        protected int|array $id,
+        protected int $upload_destination_id,
+    ) {}
+
+    /**
+     * Define which authentication methods are allowed to call this endpoint.
+     *
+     * @return AuthMethodEnum[]
+     */
+    public function allowedAuthMethods(): array
+    {
+        return [AuthMethodEnum::BEARER];
+    }
+
+    /**
+     * @param  PackageFile[]  $package_files
+     */
+    public function packageFiles(array $package_files): static
+    {
+        $this->package_files = $package_files;
+
+        return $this;
+    }
+
+    /**
+     * @param  CustomFile[]  $custom_files
+     */
+    public function customFiles(array $custom_files): static
+    {
+        $this->custom_files = $custom_files;
+
+        return $this;
+    }
+
+    public function path(string $path): static
+    {
+        $this->path = $path;
+
+        return $this;
+    }
+
+    public function catDir(int $cat_dir): static
+    {
+        if (! in_array($cat_dir, [0, 1])) {
+            throw new \InvalidArgumentException('cat_dir must be 0 or 1');
+        }
+
+        $this->cat_dir = $cat_dir;
+
+        return $this;
+    }
+
+    public function assetDir(int $asset_dir): static
+    {
+        if (! in_array($asset_dir, [0, 1])) {
+            throw new \InvalidArgumentException('asset_dir must be 0 or 1');
+        }
+
+        $this->asset_dir = $asset_dir;
+
+        return $this;
+    }
+
+    /**
+     * HTTP Method to use for request.
+     */
+    public function useHttpMethod(): HttpMethodEnum
+    {
+        return HttpMethodEnum::PUT;
+    }
+
+    /**
+     * Endpoint url.
+     */
+    public function endpointUrl(): string
+    {
+        return '/Media/Uploadtoexternal';
+    }
+
+    /**
+     * Prepares HTTP request for this endpoint.
+     */
+    public function prepareHttpRequest(PendingRequest $http): void
+    {
+        $data = [
+            'id' => $this->id,
+            'upload_destination_id' => $this->upload_destination_id,
+        ];
+
+        if ($this->package_files !== null) {
+            $package_files = [];
+
+            foreach ($this->package_files as $value) {
+                $file = $value->compileAsArray();
+                if (! empty($file)) {
+                    $package_files[] = $file;
+                }
+            }
+
+            if (! empty($package_files)) {
+                $data['package_files'] = $package_files;
+            }
+        }
+
+        if ($this->custom_files !== null) {
+            $custom_files = [];
+
+            foreach ($this->custom_files as $value) {
+                $file = $value->compileAsArray();
+                if (! empty($file)) {
+                    $custom_files[] = $file;
+                }
+            }
+
+            if (! empty($custom_files)) {
+                $data['custom_files'] = $custom_files;
+            }
+        }
+
+        if ($this->path !== null) {
+            $data['path'] = $this->path;
+        }
+
+        if ($this->cat_dir !== null) {
+            $data['cat_dir'] = $this->cat_dir;
+        }
+
+        if ($this->asset_dir !== null) {
+            $data['asset_dir'] = $this->asset_dir;
+        }
+
+        $http->withData($data);
+    }
+}

--- a/src/Endpoints/Media/UploadToExternal/CustomFile.php
+++ b/src/Endpoints/Media/UploadToExternal/CustomFile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class CustomFile
+{
+    use CompilesProperties;
+
+    public function __construct(
+        protected int $file_id,
+        protected string $filename,
+    ) {}
+}

--- a/src/Endpoints/Media/UploadToExternal/PackageFile.php
+++ b/src/Endpoints/Media/UploadToExternal/PackageFile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal;
+
+use Newman\LaravelBackscreenApiClient\Concerns\CompilesProperties;
+
+class PackageFile
+{
+    use CompilesProperties;
+
+    public function __construct(
+        protected int $package_id,
+        protected int $file_id,
+    ) {}
+}

--- a/src/Endpoints/Media/Validate.php
+++ b/src/Endpoints/Media/Validate.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\AbstractEndpoint;
+use Newman\LaravelBackscreenApiClient\Contracts\EndpointContract;
+use Newman\LaravelBackscreenApiClient\Enums\AuthMethodEnum;
+use Newman\LaravelBackscreenApiClient\Enums\HttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\HttpClient\PendingRequest;
+
+/**
+ * @link https://api.backscreen.com/api/v5/docs#/operations/Media/Validate
+ */
+class Validate extends AbstractEndpoint implements EndpointContract
+{
+    protected ?int $transcode = null;
+
+    protected ?int $transcode_priority = null;
+
+    protected ?int $transcoding_preset_id = null;
+
+    /**
+     * @param  int|array<int>  $id
+     */
+    public function __construct(protected int|array $id) {}
+
+    /**
+     * Define which authentication methods are allowed to call this endpoint.
+     *
+     * @return AuthMethodEnum[]
+     */
+    public function allowedAuthMethods(): array
+    {
+        return [AuthMethodEnum::BEARER];
+    }
+
+    /**
+     * Allowed values: 0 or 1.
+     */
+    public function transcode(int $transcode): static
+    {
+        if (! in_array($transcode, [0, 1])) {
+            throw new \InvalidArgumentException('transcode must be 0 or 1');
+        }
+
+        $this->transcode = $transcode;
+
+        return $this;
+    }
+
+    /**
+     * Allowed values: 0 (normal priority) or 1 (top priority).
+     */
+    public function transcodePriority(int $transcode_priority): static
+    {
+        if (! in_array($transcode_priority, [0, 1])) {
+            throw new \InvalidArgumentException('transcode_priority must be 0 or 1');
+        }
+
+        $this->transcode_priority = $transcode_priority;
+
+        return $this;
+    }
+
+    public function transcodingPresetId(int $transcoding_preset_id): static
+    {
+        $this->transcoding_preset_id = $transcoding_preset_id;
+
+        return $this;
+    }
+
+    /**
+     * HTTP Method to use for request.
+     */
+    public function useHttpMethod(): HttpMethodEnum
+    {
+        return HttpMethodEnum::PUT;
+    }
+
+    /**
+     * Endpoint url.
+     */
+    public function endpointUrl(): string
+    {
+        return '/Media/Validate';
+    }
+
+    /**
+     * Prepares HTTP request for this endpoint.
+     */
+    public function prepareHttpRequest(PendingRequest $http): void
+    {
+        $data = [
+            'id' => $this->id,
+        ];
+
+        if ($this->transcode !== null) {
+            $data['transcode'] = $this->transcode;
+        }
+
+        if ($this->transcode_priority !== null) {
+            $data['transcode_priority'] = $this->transcode_priority;
+        }
+
+        if ($this->transcoding_preset_id !== null) {
+            $data['transcoding_preset_id'] = $this->transcoding_preset_id;
+        }
+
+        $http->withData($data);
+    }
+}

--- a/src/HttpClient/HttpFactory.php
+++ b/src/HttpClient/HttpFactory.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Newman\LaravelBackscreenApiClient\HttpClient;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\ResponseSequence;
 use Illuminate\Support\Collection;
 
 class HttpFactory extends Factory
@@ -22,7 +26,7 @@ class HttpFactory extends Factory
     /**
      * Register a stub callable that will intercept requests and be able to return stub responses.
      *
-     * @param  callable(\Illuminate\Http\Client\Request $request, array<string, mixed> $options): (\Closure|\GuzzleHttp\Promise\PromiseInterface|\Illuminate\Http\Client\Response|null)|array<string, int|string|\Closure|\Illuminate\Http\Client\Response|\Illuminate\Http\Client\ResponseSequence|\GuzzleHttp\Promise\PromiseInterface>|null  $callback
+     * @param  callable(Request $request, array<string, mixed> $options): (\Closure|PromiseInterface|Response|null)|array<string, int|string|\Closure|Response|ResponseSequence|PromiseInterface>|null  $callback
      * @return $this
      */
     public function fake($callback = null)

--- a/src/Support/ValidateImage.php
+++ b/src/Support/ValidateImage.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Support;
+
+class ValidateImage
+{
+    /**
+     * Verify that the given value is a valid base64 encoded image string
+     * in data URI format (e.g. data:image/png;base64,<base64>).
+     */
+    public static function verify(?string $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (! str_contains($value, 'data:') || ! str_contains($value, 'base64,')) {
+            return false;
+        }
+
+        $base64 = substr($value, strpos($value, 'base64,') + \strlen('base64,'));
+
+        $decoded = base64_decode($base64, true);
+
+        if ($decoded === false) {
+            return false;
+        }
+
+        return base64_encode($decoded) === $base64;
+    }
+}

--- a/tests/Endpoints/Media/Create/AvailabilityTest.php
+++ b/tests/Endpoints/Media/Create/AvailabilityTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class AvailabilityTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $availability = new Availability;
+        $this->assertEquals([], $availability->compileAsArray());
+    }
+
+    public function test_published(): void
+    {
+        $availability = new Availability;
+        $availability->published(1);
+        $this->assertEquals(['published' => 1], $availability->compileAsArray());
+    }
+
+    public function test_published_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('published must be 0 or 1');
+        $availability->published(2);
+    }
+
+    public function test_expire_time_as_string(): void
+    {
+        $availability = new Availability;
+        $availability->expireTime('2026-03-25 12:34:56');
+        $this->assertEquals(['expire_time' => '2026-03-25 12:34:56'], $availability->compileAsArray());
+    }
+
+    public function test_expire_time_as_int(): void
+    {
+        $availability = new Availability;
+        $availability->expireTime(1774135633);
+        $this->assertEquals(['expire_time' => 1774135633], $availability->compileAsArray());
+    }
+
+    public function test_available_time(): void
+    {
+        $availability = new Availability;
+        $availability->availableTime('2026-01-01 00:00:00');
+        $this->assertEquals(['available_time' => '2026-01-01 00:00:00'], $availability->compileAsArray());
+    }
+
+    public function test_delete_source_after_transcode_hours(): void
+    {
+        $availability = new Availability;
+        $availability->deleteSourceAfterTranscodeHours(24);
+        $this->assertEquals(['delete_source_after_transcode_hours' => 24], $availability->compileAsArray());
+    }
+
+    public function test_delete_source_after_transcode_hours_with_disable(): void
+    {
+        $availability = new Availability;
+        $availability->deleteSourceAfterTranscodeHours(-1);
+        $this->assertEquals(['delete_source_after_transcode_hours' => -1], $availability->compileAsArray());
+    }
+
+    public function test_delete_source_after_transcode_hours_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('delete_source_after_transcode_hours must be >= -1');
+        $availability->deleteSourceAfterTranscodeHours(-2);
+    }
+
+    public function test_delete_source_av_after_transcode_hours(): void
+    {
+        $availability = new Availability;
+        $availability->deleteSourceAvAfterTranscodeHours(0);
+        $this->assertEquals(['delete_source_av_after_transcode_hours' => 0], $availability->compileAsArray());
+    }
+
+    public function test_delete_source_av_after_transcode_hours_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('delete_source_av_after_transcode_hours must be >= -1');
+        $availability->deleteSourceAvAfterTranscodeHours(-2);
+    }
+
+    public function test_delete_transcode_after_upload_hours(): void
+    {
+        $availability = new Availability;
+        $availability->deleteTranscodeAfterUploadHours(48);
+        $this->assertEquals(['delete_transcode_after_upload_hours' => 48], $availability->compileAsArray());
+    }
+
+    public function test_delete_transcode_after_upload_hours_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('delete_transcode_after_upload_hours must be >= -1');
+        $availability->deleteTranscodeAfterUploadHours(-2);
+    }
+
+    public function test_delete_all_after_upload_hours(): void
+    {
+        $availability = new Availability;
+        $availability->deleteAllAfterUploadHours(-1);
+        $this->assertEquals(['delete_all_after_upload_hours' => -1], $availability->compileAsArray());
+    }
+
+    public function test_delete_all_after_upload_hours_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('delete_all_after_upload_hours must be >= -1');
+        $availability->deleteAllAfterUploadHours(-2);
+    }
+
+    public function test_delete_all_after_expire_hours(): void
+    {
+        $availability = new Availability;
+        $availability->deleteAllAfterExpireHours(72);
+        $this->assertEquals(['delete_all_after_expire_hours' => 72], $availability->compileAsArray());
+    }
+
+    public function test_delete_all_after_expire_hours_invalid(): void
+    {
+        $availability = new Availability;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('delete_all_after_expire_hours must be >= -1');
+        $availability->deleteAllAfterExpireHours(-2);
+    }
+}

--- a/tests/Endpoints/Media/Create/EmbedTest.php
+++ b/tests/Endpoints/Media/Create/EmbedTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\AspectRatioEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\PlayerProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\PlayerTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class EmbedTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $embed = new Embed;
+        $this->assertEquals([], $embed->compileAsArray());
+    }
+
+    public function test_protocol(): void
+    {
+        $embed = new Embed;
+        $embed->protocol(ProtocolEnum::HTTPS);
+        $this->assertEquals(['protocol' => 'https'], $embed->compileAsArray());
+    }
+
+    public function test_player_type(): void
+    {
+        $embed = new Embed;
+        $embed->playerType(PlayerTypeEnum::VR);
+        $this->assertEquals(['player_type' => 'vr'], $embed->compileAsArray());
+    }
+
+    public function test_player_protocol(): void
+    {
+        $embed = new Embed;
+        $embed->playerProtocol(PlayerProtocolEnum::HLS);
+        $this->assertEquals(['player_protocol' => 'hls'], $embed->compileAsArray());
+    }
+
+    public function test_aspect_ratio(): void
+    {
+        $embed = new Embed;
+        $embed->aspectRatio(AspectRatioEnum::RATIO_16_9);
+        $this->assertEquals(['aspect_ratio' => '16:9'], $embed->compileAsArray());
+    }
+
+    public function test_autoplay(): void
+    {
+        $embed = new Embed;
+        $embed->autoplay(1);
+        $this->assertEquals(['autoplay' => 1], $embed->compileAsArray());
+    }
+
+    public function test_autoplay_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('autoplay must be 0 or 1');
+        $embed->autoplay(2);
+    }
+
+    public function test_autosubs(): void
+    {
+        $embed = new Embed;
+        $embed->autosubs(0);
+        $this->assertEquals(['autosubs' => 0], $embed->compileAsArray());
+    }
+
+    public function test_autosubs_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('autosubs must be 0 or 1');
+        $embed->autosubs(2);
+    }
+
+    public function test_mute(): void
+    {
+        $embed = new Embed;
+        $embed->mute(1);
+        $this->assertEquals(['mute' => 1], $embed->compileAsArray());
+    }
+
+    public function test_mute_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('mute must be 0 or 1');
+        $embed->mute(5);
+    }
+
+    public function test_start_from(): void
+    {
+        $embed = new Embed;
+        $embed->startFrom(30);
+        $this->assertEquals(['start_from' => 30], $embed->compileAsArray());
+    }
+
+    public function test_start_random(): void
+    {
+        $embed = new Embed;
+        $embed->startRandom(1);
+        $this->assertEquals(['start_random' => 1], $embed->compileAsArray());
+    }
+
+    public function test_start_random_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('start_random must be 0 or 1');
+        $embed->startRandom(2);
+    }
+
+    public function test_enable_public(): void
+    {
+        $embed = new Embed;
+        $embed->enablePublic(1);
+        $this->assertEquals(['enable_public' => 1], $embed->compileAsArray());
+    }
+
+    public function test_enable_public_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('enable_public must be 0 or 1');
+        $embed->enablePublic(2);
+    }
+
+    public function test_public_password(): void
+    {
+        $embed = new Embed;
+        $embed->publicPassword('secret');
+        $this->assertEquals(['public_password' => 'secret'], $embed->compileAsArray());
+    }
+
+    public function test_enable_preview(): void
+    {
+        $embed = new Embed;
+        $embed->enablePreview(0);
+        $this->assertEquals(['enable_preview' => 0], $embed->compileAsArray());
+    }
+
+    public function test_enable_preview_invalid(): void
+    {
+        $embed = new Embed;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('enable_preview must be 0 or 1');
+        $embed->enablePreview(2);
+    }
+}

--- a/tests/Endpoints/Media/Create/ImagesTest.php
+++ b/tests/Endpoints/Media/Create/ImagesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class ImagesTest extends TestCase
+{
+    public function test(): void
+    {
+        $images = new Images;
+
+        $encodedImage = 'data:image/png;base64,'.base64_encode('imagebase64_1');
+
+        $images->thumbnail($encodedImage)
+            ->placeholder($encodedImage);
+
+        $this->assertEquals([
+            'thumbnail' => $encodedImage,
+            'placeholder' => $encodedImage,
+        ], $images->compileAsArray());
+    }
+
+    public function test_thumbnail_with_non_base64(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('thumbnail must be a base64 encoded string');
+
+        $images->thumbnail('data:image/png;base64,imagebase64_1');
+    }
+
+    public function test_placeholder_with_non_base64(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('placeholder must be a base64 encoded string');
+
+        $images->placeholder('data:image/png;base64,imagebase64_1');
+    }
+
+    public function test_thumbnail_without_metadata(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('thumbnail must be a base64 encoded string');
+
+        $images->thumbnail('imagebase64_1');
+    }
+
+    public function test_placeholder_without_metadata(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('placeholder must be a base64 encoded string');
+
+        $images->placeholder('imagebase64_1');
+    }
+
+    public function test_thumbnail_with_null(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('thumbnail must be a base64 encoded string');
+
+        $images->thumbnail(null);
+    }
+
+    public function test_placeholder_with_null(): void
+    {
+        $images = new Images;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('placeholder must be a base64 encoded string');
+
+        $images->placeholder(null);
+    }
+}

--- a/tests/Endpoints/Media/Create/PlayerCustomTitleTest.php
+++ b/tests/Endpoints/Media/Create/PlayerCustomTitleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleFontEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleTextSizeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\PlayerCustomTitle;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class PlayerCustomTitleTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $title = new PlayerCustomTitle;
+        $this->assertEquals([], $title->compileAsArray());
+    }
+
+    public function test_text(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->text('My Title');
+        $this->assertEquals(['text' => 'My Title'], $title->compileAsArray());
+    }
+
+    public function test_url_label(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->urlLabel('https://example.com');
+        $this->assertEquals(['url_label' => 'https://example.com'], $title->compileAsArray());
+    }
+
+    public function test_type(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->type(CustomTitleTypeEnum::TOP_LEFT);
+        $this->assertEquals(['type' => 'top-left'], $title->compileAsArray());
+    }
+
+    public function test_start_and_end(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->start(10)->end(60);
+        $this->assertEquals(['start' => 10, 'end' => 60], $title->compileAsArray());
+    }
+
+    public function test_font(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->font(CustomTitleFontEnum::ARIAL);
+        $this->assertEquals(['font' => 'Arial, Helvetica, sans-serif'], $title->compileAsArray());
+    }
+
+    public function test_color_hex(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->color('#ffffff');
+        $this->assertEquals(['color' => '#ffffff'], $title->compileAsArray());
+    }
+
+    public function test_color_rgba(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->color('rgba(255,255,255,0.5)');
+        $this->assertEquals(['color' => 'rgba(255,255,255,0.5)'], $title->compileAsArray());
+    }
+
+    public function test_color_invalid(): void
+    {
+        $title = new PlayerCustomTitle;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('color must be in #ffffff or rgba(255,255,255,0.5) format');
+        $title->color('red');
+    }
+
+    public function test_background(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->background('#000000');
+        $this->assertEquals(['background' => '#000000'], $title->compileAsArray());
+    }
+
+    public function test_background_invalid(): void
+    {
+        $title = new PlayerCustomTitle;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('background must be in #ffffff or rgba(255,255,255,0.5) format');
+        $title->background('blue');
+    }
+
+    public function test_text_size(): void
+    {
+        $title = new PlayerCustomTitle;
+        $title->textSize(CustomTitleTextSizeEnum::SIZE_1_2);
+        $this->assertEquals(['text_size' => '1.2'], $title->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Create/PlayerTest.php
+++ b/tests/Endpoints/Media/Create/PlayerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\CustomTitleTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Player;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\PlayerCustomTitle;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class PlayerTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $player = new Player;
+        $this->assertEquals([], $player->compileAsArray());
+    }
+
+    public function test_logo_redirect(): void
+    {
+        $player = new Player;
+        $player->logoRedirect('https://example.com');
+        $this->assertEquals(['logo_redirect' => 'https://example.com'], $player->compileAsArray());
+    }
+
+    public function test_preload_content(): void
+    {
+        $player = new Player;
+        $player->preloadContent(1);
+        $this->assertEquals(['preload_content' => 1], $player->compileAsArray());
+    }
+
+    public function test_preload_content_invalid(): void
+    {
+        $player = new Player;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('preload_content must be 0 or 1');
+        $player->preloadContent(2);
+    }
+
+    public function test_extended_buffer(): void
+    {
+        $player = new Player;
+        $player->extendedBuffer(0);
+        $this->assertEquals(['extended_buffer' => 0], $player->compileAsArray());
+    }
+
+    public function test_extended_buffer_invalid(): void
+    {
+        $player = new Player;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('extended_buffer must be 0 or 1');
+        $player->extendedBuffer(2);
+    }
+
+    public function test_disable_pausing(): void
+    {
+        $player = new Player;
+        $player->disablePausing(1);
+        $this->assertEquals(['disable_pausing' => 1], $player->compileAsArray());
+    }
+
+    public function test_disable_pausing_invalid(): void
+    {
+        $player = new Player;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('disable_pausing must be 0 or 1');
+        $player->disablePausing(2);
+    }
+
+    public function test_custom_titles(): void
+    {
+        $player = new Player;
+
+        $title = new PlayerCustomTitle;
+        $title->text('Hello World');
+        $title->type(CustomTitleTypeEnum::BOTTOM_LEFT);
+
+        $player->customTitles([$title]);
+
+        $this->assertEquals([
+            'custom_titles' => [
+                [
+                    'text' => 'Hello World',
+                    'type' => 'bottom-left',
+                ],
+            ],
+        ], $player->compileAsArray());
+    }
+
+    public function test_singular_live(): void
+    {
+        $player = new Player;
+        $player->singularLive('stream-key');
+        $this->assertEquals(['singular_live' => 'stream-key'], $player->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Create/PresentationTest.php
+++ b/tests/Endpoints/Media/Create/PresentationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Presentation;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\PresentationConfig;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class PresentationTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $presentation = new Presentation;
+        $this->assertEquals([], $presentation->compileAsArray());
+    }
+
+    public function test_mode(): void
+    {
+        $presentation = new Presentation;
+        $presentation->mode(1);
+        $this->assertEquals(['mode' => 1], $presentation->compileAsArray());
+    }
+
+    public function test_mode_invalid(): void
+    {
+        $presentation = new Presentation;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('mode must be 0 or 1');
+        $presentation->mode(2);
+    }
+
+    public function test_config_with_file_id(): void
+    {
+        $presentation = new Presentation;
+        $config = new PresentationConfig;
+        $config->fileId(123);
+        $presentation->config($config);
+
+        $this->assertEquals([
+            'config' => ['file_id' => 123],
+        ], $presentation->compileAsArray());
+    }
+
+    public function test_config_with_url(): void
+    {
+        $presentation = new Presentation;
+        $config = new PresentationConfig;
+        $config->url('https://example.com/presentation');
+        $presentation->config($config);
+
+        $this->assertEquals([
+            'config' => ['url' => 'https://example.com/presentation'],
+        ], $presentation->compileAsArray());
+    }
+
+    public function test_config_with_slides(): void
+    {
+        $presentation = new Presentation;
+        $config = new PresentationConfig;
+        $config->slides(['slide1.jpg', 'slide2.jpg']);
+        $presentation->config($config);
+
+        $this->assertEquals([
+            'config' => ['slides' => ['slide1.jpg', 'slide2.jpg']],
+        ], $presentation->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Create/SecurityTest.php
+++ b/tests/Endpoints/Media/Create/SecurityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\TokenDurationEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class SecurityTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $security = new Security;
+        $this->assertEquals([], $security->compileAsArray());
+    }
+
+    public function test_encryption_method(): void
+    {
+        $security = new Security;
+        $security->encryptionMethod(EncryptionMethodEnum::AES);
+        $this->assertEquals(['encryption_method' => 'aes'], $security->compileAsArray());
+    }
+
+    public function test_token_duration(): void
+    {
+        $security = new Security;
+        $security->tokenDuration(TokenDurationEnum::DAY);
+        $this->assertEquals(['token_duration' => '1d'], $security->compileAsArray());
+    }
+
+    public function test_use_token(): void
+    {
+        $security = new Security;
+        $security->useToken(1);
+        $this->assertEquals(['use_token' => 1], $security->compileAsArray());
+    }
+
+    public function test_use_token_invalid(): void
+    {
+        $security = new Security;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('use_token must be 0 or 1');
+        $security->useToken(2);
+    }
+
+    public function test_use_token_full(): void
+    {
+        $security = new Security;
+        $security->useTokenFull(0);
+        $this->assertEquals(['use_token_full' => 0], $security->compileAsArray());
+    }
+
+    public function test_use_token_full_invalid(): void
+    {
+        $security = new Security;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('use_token_full must be 0 or 1');
+        $security->useTokenFull(2);
+    }
+
+    public function test_all_fields(): void
+    {
+        $security = new Security;
+        $security->encryptionMethod(EncryptionMethodEnum::DRM)
+            ->tokenDuration(TokenDurationEnum::WEEK)
+            ->useToken(1)
+            ->useTokenFull(0);
+
+        $this->assertEquals([
+            'encryption_method' => 'drm',
+            'token_duration' => '1w',
+            'use_token' => 1,
+            'use_token_full' => 0,
+        ], $security->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Create/TranscodeInfoTest.php
+++ b/tests/Endpoints/Media/Create/TranscodeInfoTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Create;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class TranscodeInfoTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $info = new TranscodeInfo;
+        $this->assertEquals([], $info->compileAsArray());
+    }
+
+    public function test_dvb_lng_order(): void
+    {
+        $info = new TranscodeInfo;
+        $info->dvbLngOrder('lv,en,ru');
+        $this->assertEquals(['dvb_lng_order' => 'lv,en,ru'], $info->compileAsArray());
+    }
+
+    public function test_preset_id(): void
+    {
+        $info = new TranscodeInfo;
+        $info->presetId(42);
+        $this->assertEquals(['preset_id' => 42], $info->compileAsArray());
+    }
+
+    public function test_preset_id_invalid(): void
+    {
+        $info = new TranscodeInfo;
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('preset_id must be >= 0');
+        $info->presetId(-1);
+    }
+
+    public function test_preset_id_zero(): void
+    {
+        $info = new TranscodeInfo;
+        $info->presetId(0);
+        $this->assertEquals(['preset_id' => 0], $info->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/CreateTest.php
+++ b/tests/Endpoints/Media/CreateTest.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\ProtocolEnum;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Player;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Presentation;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\PresentationConfig;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Tags;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as LegacyImages;
 use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class CreateTest extends TestCase
@@ -221,22 +230,219 @@ class CreateTest extends TestCase
         ]);
     }
 
-    public function test_with_callback(): void
+    public function test_with_transcode_info(): void
     {
         $endpoint = new Create('123');
 
-        $endpoint->callback([
-            new Callback('https://mysite.com', CallbackHttpMethodEnum::POST),
-        ]);
+        $info = new TranscodeInfo;
+        $info->dvbLngOrder('lv,en')->presetId(5);
+
+        $endpoint->transcodeInfo($info);
 
         $this->makeBearerAuthEndpointTest($endpoint, [], [
             'asset_id' => '123',
-            'callback' => [
-                [
-                    'url' => 'https://mysite.com',
-                    'method' => CallbackHttpMethodEnum::POST->value,
-                ],
+            'transcode_info' => [
+                'dvb_lng_order' => 'lv,en',
+                'preset_id' => 5,
             ],
+        ]);
+    }
+
+    public function test_with_empty_transcode_info(): void
+    {
+        $endpoint = new Create('123');
+
+        $endpoint->transcodeInfo(new TranscodeInfo);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_images(): void
+    {
+        $endpoint = new Create('123');
+
+        $encodedImage = 'data:image/png;base64,'.base64_encode('imagebase64_1');
+
+        $images = new Images;
+        $images->thumbnail($encodedImage);
+
+        $endpoint->images($images);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'images' => ['thumbnail' => $encodedImage],
+        ]);
+    }
+
+    public function test_with_legacy_images(): void
+    {
+        $endpoint = new Create('123');
+
+        $encodedImage = 'data:image/png;base64,'.base64_encode('imagebase64_1');
+
+        $images = new LegacyImages;
+        $images->thumbnail($encodedImage)->placeholder($encodedImage);
+
+        $endpoint->images($images);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'images' => ['thumbnail' => $encodedImage, 'placeholder' => $encodedImage],
+        ]);
+    }
+
+    public function test_with_empty_images(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->images(new Images);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_embed(): void
+    {
+        $endpoint = new Create('123');
+
+        $embed = new Embed;
+        $embed->protocol(ProtocolEnum::HTTPS)->autoplay(1);
+
+        $endpoint->embed($embed);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'embed' => [
+                'protocol' => 'https',
+                'autoplay' => 1,
+            ],
+        ]);
+    }
+
+    public function test_with_empty_embed(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->embed(new Embed);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_presentation(): void
+    {
+        $endpoint = new Create('123');
+
+        $config = new PresentationConfig;
+        $config->fileId(99);
+
+        $presentation = new Presentation;
+        $presentation->mode(1)->config($config);
+
+        $endpoint->presentation($presentation);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'presentation' => [
+                'mode' => 1,
+                'config' => ['file_id' => 99],
+            ],
+        ]);
+    }
+
+    public function test_with_empty_presentation(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->presentation(new Presentation);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_player(): void
+    {
+        $endpoint = new Create('123');
+
+        $player = new Player;
+        $player->logoRedirect('https://example.com')->preloadContent(1);
+
+        $endpoint->player($player);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'player' => [
+                'logo_redirect' => 'https://example.com',
+                'preload_content' => 1,
+            ],
+        ]);
+    }
+
+    public function test_with_empty_player(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->player(new Player);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_security(): void
+    {
+        $endpoint = new Create('123');
+
+        $security = new Security;
+        $security->encryptionMethod(EncryptionMethodEnum::AES)->useToken(1);
+
+        $endpoint->security($security);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'security' => [
+                'encryption_method' => 'aes',
+                'use_token' => 1,
+            ],
+        ]);
+    }
+
+    public function test_with_empty_security(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->security(new Security);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+        ]);
+    }
+
+    public function test_with_availability(): void
+    {
+        $endpoint = new Create('123');
+
+        $availability = new Availability;
+        $availability->published(1)->expireTime('2026-12-31 23:59:59');
+
+        $endpoint->availability($availability);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
+            'availability' => [
+                'published' => 1,
+                'expire_time' => '2026-12-31 23:59:59',
+            ],
+        ]);
+    }
+
+    public function test_with_empty_availability(): void
+    {
+        $endpoint = new Create('123');
+        $endpoint->availability(new Availability);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'asset_id' => '123',
         ]);
     }
 }

--- a/tests/Endpoints/Media/MediaList/MediaInfoTest.php
+++ b/tests/Endpoints/Media/MediaList/MediaInfoTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\MediaList;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\MediaInfo;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class MediaInfoTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $info = new MediaInfo;
+        $this->assertEquals([], $info->compileAsArray());
+    }
+
+    public function test_resolution(): void
+    {
+        $info = new MediaInfo;
+        $info->resolution(['1920x1080', '1280x720']);
+        $this->assertEquals(['resolution' => ['1920x1080', '1280x720']], $info->compileAsArray());
+    }
+
+    public function test_length(): void
+    {
+        $info = new MediaInfo;
+        $info->length(['00:01:00', '00:02:00']);
+        $this->assertEquals(['length' => ['00:01:00', '00:02:00']], $info->compileAsArray());
+    }
+
+    public function test_gop_type(): void
+    {
+        $info = new MediaInfo;
+        $info->gopType(['open']);
+        $this->assertEquals(['gop_type' => ['open']], $info->compileAsArray());
+    }
+
+    public function test_gop_size(): void
+    {
+        $info = new MediaInfo;
+        $info->gopSize(['25', '50']);
+        $this->assertEquals(['gop_size' => ['25', '50']], $info->compileAsArray());
+    }
+
+    public function test_frame_rate(): void
+    {
+        $info = new MediaInfo;
+        $info->frameRate(['25', '29.97']);
+        $this->assertEquals(['frame_rate' => ['25', '29.97']], $info->compileAsArray());
+    }
+
+    public function test_content_type(): void
+    {
+        $info = new MediaInfo;
+        $info->contentType(['sdr', 'hdr']);
+        $this->assertEquals(['content_type' => ['sdr', 'hdr']], $info->compileAsArray());
+    }
+
+    public function test_audio_type(): void
+    {
+        $info = new MediaInfo;
+        $info->audioType(['stereo', '5.1']);
+        $this->assertEquals(['audio_type' => ['stereo', '5.1']], $info->compileAsArray());
+    }
+
+    public function test_audio_tracks_count(): void
+    {
+        $info = new MediaInfo;
+        $info->audioTracksCount(['1', '2']);
+        $this->assertEquals(['audio_tracks_count' => ['1', '2']], $info->compileAsArray());
+    }
+
+    public function test_codec(): void
+    {
+        $info = new MediaInfo;
+        $info->codec(['h264', 'h265']);
+        $this->assertEquals(['codec' => ['h264', 'h265']], $info->compileAsArray());
+    }
+
+    public function test_language(): void
+    {
+        $info = new MediaInfo;
+        $info->language(['lv', 'en']);
+        $this->assertEquals(['language' => ['lv', 'en']], $info->compileAsArray());
+    }
+
+    public function test_subtitle_language(): void
+    {
+        $info = new MediaInfo;
+        $info->subtitleLanguage(['lv', 'ru']);
+        $this->assertEquals(['subtitle_language' => ['lv', 'ru']], $info->compileAsArray());
+    }
+
+    public function test_audio_language(): void
+    {
+        $info = new MediaInfo;
+        $info->audioLanguage(['en']);
+        $this->assertEquals(['audio_language' => ['en']], $info->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/MediaListTest.php
+++ b/tests/Endpoints/Media/MediaListTest.php
@@ -6,6 +6,11 @@ namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
 use Carbon\Carbon;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\FileExtension;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\MediaInfo;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\PeriodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\Popular;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\MediaList\PopularSourceEnum;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\OrderDirectionEnum;
 use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
@@ -317,5 +322,243 @@ class MediaListTest extends TestCase
         $this->makeBasicAuthEndpointTest($endpoint, [
             'return' => ['actions', 'tech_status'],
         ]);
+    }
+
+    public function test_with_id_from(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->idFrom(100);
+
+        $this->makeBasicAuthEndpointTest($endpoint, ['id_from' => 100]);
+    }
+
+    public function test_with_id_to(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->idTo(500);
+
+        $this->makeBasicAuthEndpointTest($endpoint, ['id_to' => 500]);
+    }
+
+    public function test_with_created_period(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->createdPeriod(PeriodEnum::LAST_7_DAYS);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'created_period' => PeriodEnum::LAST_7_DAYS->value,
+        ]);
+    }
+
+    public function test_with_updated_period(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->updatedPeriod(PeriodEnum::THIS_MONTH);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'updated_period' => PeriodEnum::THIS_MONTH->value,
+        ]);
+    }
+
+    public function test_with_published_from(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->publishedFrom('2023-01-01 00:00:00');
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'published_from' => '2023-01-01 00:00:00',
+        ]);
+    }
+
+    public function test_with_published_to(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->publishedTo(Carbon::create(2023, 6, 30, 23, 59, 59));
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'published_to' => '2023-06-30 23:59:59',
+        ]);
+    }
+
+    public function test_with_published_period(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->publishedPeriod(PeriodEnum::LAST_30_DAYS);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'published_period' => PeriodEnum::LAST_30_DAYS->value,
+        ]);
+    }
+
+    public function test_with_name_string(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->name('Test%');
+
+        $this->makeBasicAuthEndpointTest($endpoint, ['name' => 'Test%']);
+    }
+
+    public function test_with_name_array(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->name(['Test%', 'Demo%']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'name' => ['Test%', 'Demo%'],
+        ]);
+    }
+
+    public function test_with_pg_rating(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->pgRating('PG-13');
+
+        $this->makeBasicAuthEndpointTest($endpoint, ['pg_rating' => 'PG-13']);
+    }
+
+    public function test_with_status_exclude(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->statusExclude(MediaList\StatusEnum::ARCHIVED);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'status_exclude' => [MediaList\StatusEnum::ARCHIVED->value],
+        ]);
+    }
+
+    public function test_with_tech_status(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->techStatus(['transcoded', 'published']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'tech_status' => ['transcoded', 'published'],
+        ]);
+    }
+
+    public function test_with_tech_status_exclude(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->techStatusExclude(['error', 'warning']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'tech_status_exclude' => ['error', 'warning'],
+        ]);
+    }
+
+    public function test_with_errors_warnings(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->errorsWarnings(['missing_thumbnail']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'errors_warnings' => ['missing_thumbnail'],
+        ]);
+    }
+
+    public function test_with_file_extension(): void
+    {
+        $endpoint = new MediaList;
+
+        $fileExtension = new FileExtension;
+        $fileExtension->source(['mp4', 'mov']);
+
+        $endpoint->fileExtension($fileExtension);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'file_extension' => ['source' => ['mp4', 'mov']],
+        ]);
+    }
+
+    public function test_with_empty_file_extension(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->fileExtension(new FileExtension);
+
+        $this->makeBasicAuthEndpointTest($endpoint, []);
+    }
+
+    public function test_with_media_info(): void
+    {
+        $endpoint = new MediaList;
+
+        $mediaInfo = new MediaInfo;
+        $mediaInfo->resolution(['1920x1080'])->codec(['h264']);
+
+        $endpoint->mediaInfo($mediaInfo);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'media_info' => [
+                'resolution' => ['1920x1080'],
+                'codec' => ['h264'],
+            ],
+        ]);
+    }
+
+    public function test_with_popular(): void
+    {
+        $endpoint = new MediaList;
+
+        $popular = new Popular;
+        $popular->source(PopularSourceEnum::YOUBORA)
+            ->dateFrom('2023-01-01')
+            ->dateTo('2023-12-31')
+            ->orderDir(OrderDirectionEnum::DESC);
+
+        $endpoint->popular($popular);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'popular' => [
+                'source' => 'youbora',
+                'date_from' => '2023-01-01',
+                'date_to' => '2023-12-31',
+                'order_dir' => 'desc',
+            ],
+        ]);
+    }
+
+    public function test_with_popular_period(): void
+    {
+        $endpoint = new MediaList;
+
+        $popular = new Popular;
+        $popular->source(PopularSourceEnum::INTERNAL)->datePeriod(PeriodEnum::LAST_7_DAYS);
+
+        $endpoint->popular($popular);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'popular' => [
+                'source' => 'internal',
+                'date_period' => 'last 7 days',
+            ],
+        ]);
+    }
+
+    public function test_with_order_specific(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->orderSpecific([3, 1, 2]);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'order_specific' => [3, 1, 2],
+        ]);
+    }
+
+    public function test_with_metadata(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->metadata(['custom_field' => 'value']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [
+            'metadata' => ['custom_field' => 'value'],
+        ]);
+    }
+
+    public function test_with_timezone(): void
+    {
+        $endpoint = new MediaList;
+        $endpoint->timezone('Europe/Riga');
+
+        $this->makeBasicAuthEndpointTest($endpoint, ['timezone' => 'Europe/Riga']);
     }
 }

--- a/tests/Endpoints/Media/PublishTest.php
+++ b/tests/Endpoints/Media/PublishTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Publish;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
+
+class PublishTest extends TestCase
+{
+    public function test_with_single_id_published(): void
+    {
+        $this->makeBearerAuthEndpointTest(new Publish(123, 1), [], [
+            'id' => 123,
+            'published' => 1,
+        ]);
+    }
+
+    public function test_with_single_id_unpublished(): void
+    {
+        $this->makeBearerAuthEndpointTest(new Publish(123, 0), [], [
+            'id' => 123,
+            'published' => 0,
+        ]);
+    }
+
+    public function test_with_multiple_ids(): void
+    {
+        $this->makeBearerAuthEndpointTest(new Publish([1, 2, 3], 1), [], [
+            'id' => [1, 2, 3],
+            'published' => 1,
+        ]);
+    }
+
+    public function test_published_invalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('published must be 0 or 1');
+        new Publish(123, 2);
+    }
+}

--- a/tests/Endpoints/Media/RemoveWarningTest.php
+++ b/tests/Endpoints/Media/RemoveWarningTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\RemoveWarning;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
+
+class RemoveWarningTest extends TestCase
+{
+    public function test_with_basic_auth(): void
+    {
+        $this->makeBasicAuthEndpointTest(new RemoveWarning(123, 'some_warning'), [], [
+            'id' => 123,
+            'warning' => 'some_warning',
+        ]);
+    }
+
+    public function test_with_bearer_auth(): void
+    {
+        $this->makeBearerAuthEndpointTest(new RemoveWarning(456, 'other_warning'), [], [
+            'id' => 456,
+            'warning' => 'other_warning',
+        ]);
+    }
+}

--- a/tests/Endpoints/Media/Update/ImagesTest.php
+++ b/tests/Endpoints/Media/Update/ImagesTest.php
@@ -16,15 +16,11 @@ class ImagesTest extends TestCase
         $encodedImage = 'data:image/png;base64,'.base64_encode('imagebase64_1');
 
         $images->thumbnail($encodedImage)
-            ->placeholder($encodedImage)
-            ->playbutton($encodedImage)
-            ->logo($encodedImage);
+            ->placeholder($encodedImage);
 
         $this->assertEquals([
             'thumbnail' => $encodedImage,
             'placeholder' => $encodedImage,
-            'playbutton' => $encodedImage,
-            'logo' => $encodedImage,
         ], $images->compileAsArray());
     }
 
@@ -43,18 +39,6 @@ class ImagesTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertEquals('placeholder must be a base64 encoded string', $e->getMessage());
         }
-
-        try {
-            $images->playbutton('data:image/png;base64,imagebase64_1');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('playbutton must be a base64 encoded string', $e->getMessage());
-        }
-
-        try {
-            $images->logo('data:image/png;base64,imagebase64_1');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('logo must be a base64 encoded string', $e->getMessage());
-        }
     }
 
     public function test_without_metadata(): void
@@ -72,18 +56,6 @@ class ImagesTest extends TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertEquals('placeholder must be a base64 encoded string', $e->getMessage());
         }
-
-        try {
-            $images->playbutton('imagebase64_1');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('playbutton must be a base64 encoded string', $e->getMessage());
-        }
-
-        try {
-            $images->logo('imagebase64_1');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('logo must be a base64 encoded string', $e->getMessage());
-        }
     }
 
     public function test_with_null(): void
@@ -100,18 +72,6 @@ class ImagesTest extends TestCase
             $images->placeholder(null);
         } catch (\InvalidArgumentException $e) {
             $this->assertEquals('placeholder must be a base64 encoded string', $e->getMessage());
-        }
-
-        try {
-            $images->playbutton(null);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('playbutton must be a base64 encoded string', $e->getMessage());
-        }
-
-        try {
-            $images->logo(null);
-        } catch (\InvalidArgumentException $e) {
-            $this->assertEquals('logo must be a base64 encoded string', $e->getMessage());
         }
     }
 }

--- a/tests/Endpoints/Media/Update/MaterialChangeTest.php
+++ b/tests/Endpoints/Media/Update/MaterialChangeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Enums\MaterialChangeTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\MaterialChange;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class MaterialChangeTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $change = new MaterialChange;
+        $this->assertEquals([], $change->compileAsArray());
+    }
+
+    public function test_type(): void
+    {
+        $change = new MaterialChange;
+        $change->type(MaterialChangeTypeEnum::THUMBNAIL);
+        $this->assertEquals(['type' => 'thumbnail'], $change->compileAsArray());
+    }
+
+    public function test_timestamp(): void
+    {
+        $change = new MaterialChange;
+        $change->timestamp(1674135633);
+        $this->assertEquals(['timestamp' => 1674135633], $change->compileAsArray());
+    }
+
+    public function test_all_fields(): void
+    {
+        $change = new MaterialChange;
+        $change->type(MaterialChangeTypeEnum::PLACEHOLDER)->timestamp(1674135633);
+
+        $this->assertEquals([
+            'type' => 'placeholder',
+            'timestamp' => 1674135633,
+        ], $change->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Update/TagsTest.php
+++ b/tests/Endpoints/Media/Update/TagsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Tags;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class TagsTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $tags = new Tags;
+        $this->assertEquals([], $tags->compileAsArray());
+    }
+
+    public function test_set(): void
+    {
+        $tags = new Tags;
+        $tags->set(['tag1', 'tag2']);
+        $this->assertEquals(['set' => ['tag1', 'tag2']], $tags->compileAsArray());
+    }
+
+    public function test_add(): void
+    {
+        $tags = new Tags;
+        $tags->add(['tag3']);
+        $this->assertEquals(['add' => ['tag3']], $tags->compileAsArray());
+    }
+
+    public function test_remove(): void
+    {
+        $tags = new Tags;
+        $tags->remove(['tag1']);
+        $this->assertEquals(['remove' => ['tag1']], $tags->compileAsArray());
+    }
+
+    public function test_all_fields(): void
+    {
+        $tags = new Tags;
+        $tags->set(['tag1', 'tag2'])->add(['tag3'])->remove(['tag4']);
+
+        $this->assertEquals([
+            'set' => ['tag1', 'tag2'],
+            'add' => ['tag3'],
+            'remove' => ['tag4'],
+        ], $tags->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/Update/UpdateManifestTest.php
+++ b/tests/Endpoints/Media/Update/UpdateManifestTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media\Update;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Enums\MaterialChangeTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\MaterialChange;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\UpdateManifest;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class UpdateManifestTest extends TestCase
+{
+    public function test_empty(): void
+    {
+        $manifest = new UpdateManifest;
+        $this->assertEquals([], $manifest->compileAsArray());
+    }
+
+    public function test_id(): void
+    {
+        $manifest = new UpdateManifest;
+        $manifest->id(42);
+        $this->assertEquals(['id' => 42], $manifest->compileAsArray());
+    }
+
+    public function test_start_at(): void
+    {
+        $manifest = new UpdateManifest;
+        $manifest->startAt(100);
+        $this->assertEquals(['start_at' => 100], $manifest->compileAsArray());
+    }
+
+    public function test_end_at(): void
+    {
+        $manifest = new UpdateManifest;
+        $manifest->endAt(200);
+        $this->assertEquals(['end_at' => 200], $manifest->compileAsArray());
+    }
+
+    public function test_material_change(): void
+    {
+        $manifest = new UpdateManifest;
+        $change = new MaterialChange;
+        $change->type(MaterialChangeTypeEnum::THUMBNAIL)->timestamp(1674135633);
+        $manifest->materialChange($change);
+
+        $this->assertEquals([
+            'material_change' => [
+                'type' => 'thumbnail',
+                'timestamp' => 1674135633,
+            ],
+        ], $manifest->compileAsArray());
+    }
+
+    public function test_all_fields(): void
+    {
+        $manifest = new UpdateManifest;
+        $change = new MaterialChange;
+        $change->type(MaterialChangeTypeEnum::PLACEHOLDER);
+
+        $manifest->id(1)->startAt(0)->endAt(300)->materialChange($change);
+
+        $this->assertEquals([
+            'id' => 1,
+            'start_at' => 0,
+            'end_at' => 300,
+            'material_change' => ['type' => 'placeholder'],
+        ], $manifest->compileAsArray());
+    }
+}

--- a/tests/Endpoints/Media/UpdateTest.php
+++ b/tests/Endpoints/Media/UpdateTest.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
 
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Availability;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\EncryptionMethodEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Enums\ProtocolEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Files;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Player;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Presentation;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\Security;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Create\TranscodeInfo;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByAssetId;
 use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\ByMediaId;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Embed;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Enums\MaterialChangeTypeEnum;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Images;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\MaterialChange;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\Tags;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Update\UpdateManifest;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Callback;
 use Newman\LaravelBackscreenApiClient\EndpointSupport\Enums\CallbackHttpMethodEnum;
-use Newman\LaravelBackscreenApiClient\EndpointSupport\Images;
+use Newman\LaravelBackscreenApiClient\EndpointSupport\Images as LegacyImages;
 use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
 
 class UpdateTest extends TestCase
@@ -88,6 +102,353 @@ class UpdateTest extends TestCase
                     'method' => CallbackHttpMethodEnum::POST->value,
                 ],
             ],
+        ]);
+    }
+
+    public function test_with_cat_id(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->catId(99);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'cat_id' => 99,
+        ]);
+    }
+
+    public function test_with_pg_rating(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->pgRating('PG-13');
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'pg_rating' => 'PG-13',
+        ]);
+    }
+
+    public function test_with_auto_transcode(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->autoTranscode(1);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'auto_transcode' => 1,
+        ]);
+    }
+
+    public function test_with_embed_player_id(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->embedPlayerId(456);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'embed_player_id' => 456,
+        ]);
+    }
+
+    public function test_with_embed_player_id_inherit(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->embedPlayerId(-1);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'embed_player_id' => -1,
+        ]);
+    }
+
+    public function test_with_embed_player_id_invalid(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('embed_player_id must be >= -1');
+        $endpoint->embedPlayerId(-2);
+    }
+
+    public function test_with_embed_ad_id(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->embedAdId(789);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'embed_ad_id' => 789,
+        ]);
+    }
+
+    public function test_with_embed_ad_id_invalid(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('embed_ad_id must be >= -1');
+        $endpoint->embedAdId(-2);
+    }
+
+    public function test_with_embed_protection_id(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->embedProtectionId(987);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'embed_protection_id' => 987,
+        ]);
+    }
+
+    public function test_with_embed_protection_id_invalid(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('embed_protection_id must be >= -1');
+        $endpoint->embedProtectionId(-2);
+    }
+
+    public function test_with_transcode_info(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $info = new TranscodeInfo;
+        $info->presetId(10);
+
+        $endpoint->transcodeInfo($info);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'transcode_info' => ['preset_id' => 10],
+        ]);
+    }
+
+    public function test_with_empty_transcode_info(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->transcodeInfo(new TranscodeInfo);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+        ]);
+    }
+
+    public function test_with_legacy_images(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $encodedImage = 'data:image/png;base64,'.base64_encode('imagebase64_1');
+
+        $legacyImages = new LegacyImages;
+        $legacyImages->thumbnail($encodedImage)->placeholder($encodedImage);
+
+        $endpoint->images($legacyImages);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'images' => ['thumbnail' => $encodedImage, 'placeholder' => $encodedImage],
+        ]);
+    }
+
+    public function test_with_embed(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $embed = new Embed;
+        $embed->protocol(ProtocolEnum::HTTPS)->mute(1);
+
+        $endpoint->embed($embed);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'embed' => [
+                'protocol' => 'https',
+                'mute' => 1,
+            ],
+        ]);
+    }
+
+    public function test_with_empty_embed(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->embed(new Embed);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+        ]);
+    }
+
+    public function test_with_presentation(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $presentation = new Presentation;
+        $presentation->mode(0);
+
+        $endpoint->presentation($presentation);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'presentation' => ['mode' => 0],
+        ]);
+    }
+
+    public function test_with_player(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $player = new Player;
+        $player->preloadContent(0);
+
+        $endpoint->player($player);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'player' => ['preload_content' => 0],
+        ]);
+    }
+
+    public function test_with_files(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $file = new Files;
+        $file->url('https://mysite.com')->lang('lv');
+
+        $endpoint->files([$file]);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'files' => [
+                ['url' => 'https://mysite.com', 'lang' => 'lv'],
+            ],
+        ]);
+    }
+
+    public function test_with_empty_files(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->files([new Files]);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+        ]);
+    }
+
+    public function test_with_security(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $security = new Security;
+        $security->encryptionMethod(EncryptionMethodEnum::DRM);
+
+        $endpoint->security($security);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'security' => ['encryption_method' => 'drm'],
+        ]);
+    }
+
+    public function test_with_availability(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $availability = new Availability;
+        $availability->published(0);
+
+        $endpoint->availability($availability);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'availability' => ['published' => 0],
+        ]);
+    }
+
+    public function test_with_metadata(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->metadata(['key' => 'value']);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'metadata' => ['key' => 'value'],
+        ]);
+    }
+
+    public function test_with_timezone(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->timezone('Europe/Riga');
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'timezone' => 'Europe/Riga',
+        ]);
+    }
+
+    public function test_with_tags(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $tags = new Tags;
+        $tags->set(['tag1'])->add(['tag2'])->remove(['tag3']);
+
+        $endpoint->tags($tags);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'tags' => [
+                'remove' => ['tag3'],
+                'set' => ['tag1'],
+                'add' => ['tag2'],
+            ],
+        ]);
+    }
+
+    public function test_with_empty_tags(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->tags(new Tags);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+        ]);
+    }
+
+    public function test_with_update_manifests(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+
+        $change = new MaterialChange;
+        $change->type(MaterialChangeTypeEnum::THUMBNAIL)->timestamp(1674135633);
+
+        $manifest = new UpdateManifest;
+        $manifest->id(5)->startAt(0)->endAt(120)->materialChange($change);
+
+        $endpoint->updateManifests([$manifest]);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
+            'update_manifests' => [
+                [
+                    'id' => 5,
+                    'start_at' => 0,
+                    'end_at' => 120,
+                    'material_change' => [
+                        'type' => 'thumbnail',
+                        'timestamp' => 1674135633,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_with_empty_update_manifests(): void
+    {
+        $endpoint = new Update(new ByMediaId(1234));
+        $endpoint->updateManifests([new UpdateManifest]);
+
+        $this->makeBasicAuthEndpointTest($endpoint, [], [
+            'id' => 1234,
         ]);
     }
 }

--- a/tests/Endpoints/Media/UploadToExternalTest.php
+++ b/tests/Endpoints/Media/UploadToExternalTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\CustomFile;
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\UploadToExternal\PackageFile;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
+
+class UploadToExternalTest extends TestCase
+{
+    public function test_with_required_arguments(): void
+    {
+        $this->makeBearerAuthEndpointTest(new UploadToExternal(123, 456), [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+        ]);
+    }
+
+    public function test_with_multiple_ids(): void
+    {
+        $this->makeBearerAuthEndpointTest(new UploadToExternal([1, 2], 99), [], [
+            'id' => [1, 2],
+            'upload_destination_id' => 99,
+        ]);
+    }
+
+    public function test_with_package_files(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $endpoint->packageFiles([
+            new PackageFile(10, 20),
+            new PackageFile(11, 21),
+        ]);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+            'package_files' => [
+                ['package_id' => 10, 'file_id' => 20],
+                ['package_id' => 11, 'file_id' => 21],
+            ],
+        ]);
+    }
+
+    public function test_with_custom_files(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $endpoint->customFiles([
+            new CustomFile(5, 'video.mp4'),
+        ]);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+            'custom_files' => [
+                ['file_id' => 5, 'filename' => 'video.mp4'],
+            ],
+        ]);
+    }
+
+    public function test_with_path(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $endpoint->path('/my/custom/path');
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+            'path' => '/my/custom/path',
+        ]);
+    }
+
+    public function test_with_cat_dir(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $endpoint->catDir(1);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+            'cat_dir' => 1,
+        ]);
+    }
+
+    public function test_cat_dir_invalid(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cat_dir must be 0 or 1');
+        $endpoint->catDir(2);
+    }
+
+    public function test_with_asset_dir(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $endpoint->assetDir(0);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'upload_destination_id' => 456,
+            'asset_dir' => 0,
+        ]);
+    }
+
+    public function test_asset_dir_invalid(): void
+    {
+        $endpoint = new UploadToExternal(123, 456);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('asset_dir must be 0 or 1');
+        $endpoint->assetDir(2);
+    }
+}

--- a/tests/Endpoints/Media/ValidateTest.php
+++ b/tests/Endpoints/Media/ValidateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Endpoints\Media;
+
+use Newman\LaravelBackscreenApiClient\Endpoints\Media\Validate;
+use Newman\LaravelBackscreenApiClient\Tests\Endpoints\TestCase;
+
+class ValidateTest extends TestCase
+{
+    public function test_with_single_id(): void
+    {
+        $this->makeBearerAuthEndpointTest(new Validate(123), [], [
+            'id' => 123,
+        ]);
+    }
+
+    public function test_with_multiple_ids(): void
+    {
+        $this->makeBearerAuthEndpointTest(new Validate([1, 2, 3]), [], [
+            'id' => [1, 2, 3],
+        ]);
+    }
+
+    public function test_with_transcode(): void
+    {
+        $endpoint = new Validate(123);
+        $endpoint->transcode(1);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'transcode' => 1,
+        ]);
+    }
+
+    public function test_transcode_invalid(): void
+    {
+        $endpoint = new Validate(123);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('transcode must be 0 or 1');
+        $endpoint->transcode(2);
+    }
+
+    public function test_with_transcode_priority(): void
+    {
+        $endpoint = new Validate(123);
+        $endpoint->transcodePriority(1);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'transcode_priority' => 1,
+        ]);
+    }
+
+    public function test_transcode_priority_invalid(): void
+    {
+        $endpoint = new Validate(123);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('transcode_priority must be 0 or 1');
+        $endpoint->transcodePriority(2);
+    }
+
+    public function test_with_transcoding_preset_id(): void
+    {
+        $endpoint = new Validate(123);
+        $endpoint->transcodingPresetId(42);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => 123,
+            'transcoding_preset_id' => 42,
+        ]);
+    }
+
+    public function test_with_all_fields(): void
+    {
+        $endpoint = new Validate([10, 20]);
+        $endpoint->transcode(1)->transcodePriority(0)->transcodingPresetId(5);
+
+        $this->makeBearerAuthEndpointTest($endpoint, [], [
+            'id' => [10, 20],
+            'transcode' => 1,
+            'transcode_priority' => 0,
+            'transcoding_preset_id' => 5,
+        ]);
+    }
+}

--- a/tests/Support/ValidateImageTest.php
+++ b/tests/Support/ValidateImageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Newman\LaravelBackscreenApiClient\Tests\Support;
+
+use Newman\LaravelBackscreenApiClient\Support\ValidateImage;
+use Newman\LaravelBackscreenApiClient\Tests\TestCase;
+
+class ValidateImageTest extends TestCase
+{
+    public function test_null_returns_false(): void
+    {
+        $this->assertFalse(ValidateImage::verify(null));
+    }
+
+    public function test_valid_base64_image(): void
+    {
+        $encoded = 'data:image/png;base64,'.base64_encode('imagedata');
+        $this->assertTrue(ValidateImage::verify($encoded));
+    }
+
+    public function test_without_data_prefix_returns_false(): void
+    {
+        $encoded = base64_encode('imagedata');
+        $this->assertFalse(ValidateImage::verify($encoded));
+    }
+
+    public function test_without_base64_marker_returns_false(): void
+    {
+        $this->assertFalse(ValidateImage::verify('data:image/png;imagebase64'));
+    }
+
+    public function test_invalid_base64_returns_false(): void
+    {
+        $this->assertFalse(ValidateImage::verify('data:image/png;base64,not_valid_base64!!!'));
+    }
+
+    public function test_jpeg_image(): void
+    {
+        $encoded = 'data:image/jpeg;base64,'.base64_encode('fakejpegdata');
+        $this->assertTrue(ValidateImage::verify($encoded));
+    }
+}


### PR DESCRIPTION
Brought existing Media/* endpoints up-to-date with the current Backscreen API documentation.
Added missing endpoints.
Added seperate classes for Create/Update endpoint subclasses (for example Images).
Removed Callback from Meida/Create and Update endpoints.

Updated Endpoints:
- Media/Create
- Media/Update

Added Endpoints:
- Media/Validate
- Media/Publish
- Media/Uploadtoexternal

Updated existing tests and added tests for new endpoints.